### PR TITLE
Fix MSSQLServerDNSAlias and add examples

### DIFF
--- a/examples/sql/mssqlserverdnsalias.yaml
+++ b/examples/sql/mssqlserverdnsalias.yaml
@@ -1,0 +1,60 @@
+apiVersion: sql.azure.upbound.io/v1beta1
+kind: MSSQLServerDNSAlias
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta1/mssqlserverdnsalias
+  labels:
+    testing.upbound.io/example-name: example-dns-alias
+  name: example-dns-alias
+spec:
+  forProvider:
+    mssqlServerIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-dns-alias
+
+---
+
+apiVersion: sql.azure.upbound.io/v1beta1
+kind: MSSQLServer
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta1/mssqlserverdnsalias
+  labels:
+    testing.upbound.io/example-name: example-dns-alias
+  name: ${Rand.RFC1123Subdomain}-dns-alias
+spec:
+  forProvider:
+    administratorLogin: missadministrator
+    administratorLoginPasswordSecretRef:
+      key: password
+      name: example-secret
+      namespace: upbound-system
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-dns-alias
+    version: "12.0"
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta1/mssqlserverdnsalias
+  labels:
+    testing.upbound.io/example-name: example-dns-alias
+  name: example-dns-alias-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    location: West Europe
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+  namespace: upbound-system
+type: Opaque
+data:
+  password: dGVzdFBhc3N3b3JkITEyMw== # testPassword!123


### PR DESCRIPTION
### Description of your changes

This PR fixes #27 with [the fix](https://github.com/hashicorp/terraform-provider-azurerm/pull/18619) implemented in the native terraform provider by updating to the latest version, i.e. `v3.27.0`. It also adds examples to have it tested with automation.

Fixes #27

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```shell
make uptest-local EXAMPLE_LIST=examples/sql/mssqlserverdnsalias.yaml
```

```shell
kubectl get managed
NAME                                                           READY   SYNCED   EXTERNAL-NAME                   AGE
resourcegroup.azure.upbound.io/example-dns-alias-op-antar2xe   True    True     example-dns-alias-op-antar2xe   6m22s

NAME                                                         READY   SYNCED   EXTERNAL-NAME       AGE
mssqlserverdnsalias.sql.azure.upbound.io/example-dns-alias   True    True     example-dns-alias   6m23s

NAME                                                     READY   SYNCED   EXTERNAL-NAME           AGE
mssqlserver.sql.azure.upbound.io/op-2783f8w1-dns-alias   True    True     op-2783f8w1-dns-alias   6m23s
```
