### PR TITLE
Log a deprecation message when the monolithic provider is run.

### DIFF
--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -76,6 +76,10 @@ func main() {
 		ctrl.SetLogger(zl)
 	}
 
+	log.Info("warning: The monolithic package is deprecated in favor of the Azure family's resource packages " +
+		"and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages " +
+		"as we will no longer be publishing new versions of the monolithic package.")
+
 	// currently, we configure the jitter to be the 5% of the poll interval
 	pollJitter := time.Duration(float64(*pollInterval) * 0.05)
 	log.Debug("Starting", "sync-interval", syncInterval.String(),

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -78,7 +78,8 @@ func main() {
 
 	log.Info("warning: The monolithic package is deprecated in favor of the Azure family's resource packages " +
 		"and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages " +
-		"as we will no longer be publishing new versions of the monolithic package.")
+		"as we will no longer be publishing new versions of the monolithic package." +
+		"You can find more information about the provider families from the following link: https://docs.upbound.io/providers/provider-families/")
 
 	// currently, we configure the jitter to be the 5% of the poll interval
 	pollJitter := time.Duration(float64(*pollInterval) * 0.05)

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -78,7 +78,8 @@ func main() {
 {{ if eq .Group "monolith" }}
 	log.Info("warning: The monolithic package is deprecated in favor of the Azure family's resource packages " +
 		"and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages " +
-		"as we will no longer be publishing new versions of the monolithic package.")
+		"as we will no longer be publishing new versions of the monolithic package." +
+		"You can find more information about the provider families from the following link: https://docs.upbound.io/providers/provider-families/")
 {{ end }}
 	// currently, we configure the jitter to be the 5% of the poll interval
 	pollJitter := time.Duration(float64(*pollInterval) * 0.05)

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -75,7 +75,11 @@ func main() {
 		// logger when we're running in debug mode.
 		ctrl.SetLogger(zl)
 	}
-
+{{ if eq .Group "monolith" }}
+	log.Info("warning: The monolithic package is deprecated in favor of the Azure family's resource packages " +
+		"and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages " +
+		"as we will no longer be publishing new versions of the monolithic package.")
+{{ end }}
 	// currently, we configure the jitter to be the 5% of the poll interval
 	pollJitter := time.Duration(float64(*pollInterval) * 0.05)
 	log.Debug("Starting", "sync-interval", syncInterval.String(),

--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
 {{ end }}
   annotations:
     meta.crossplane.io/maintainer: Upbound <support@upbound.io>
-    meta.crossplane.io/source: github.com/upbound/provider-{{ .ProviderName }}
+    meta.crossplane.io/source: github.com/crossplane-contrib/provider-upjet-{{ .ProviderName }}
     meta.crossplane.io/description: |
       Upbound's official Crossplane provider to manage Microsoft Azure
       {{ .Service }} services in Kubernetes.
@@ -19,6 +19,13 @@ metadata:
       Marketplace](https://marketplace.upbound.io/providers/upbound/provider-{{ .ProviderName }}).
       If you encounter an issue please reach out on support@upbound.io email
       address. This is a subpackage for the {{ .Service }} API group.
+      {{ if eq .Service "monolith" }}
+      <br>
+      **Deprecation Notice:** The monolithic package is deprecated in favor of the Azure family's
+      resource packages and will no longer be maintained after 12 June 2024. Please consider
+      switching to the family provider packages as we will no longer be publishing new versions
+      of the monolithic package.
+      {{ end }}
     friendly-name.meta.crossplane.io: Provider Azure ({{ .Service }})
     auth.upbound.io/group: {{ .ProviderName }}.upbound.io
 spec:

--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -13,19 +13,19 @@ metadata:
       Upbound's official Crossplane provider to manage Microsoft Azure
       {{ .Service }} services in Kubernetes.
     meta.crossplane.io/readme: |
+      {{ if eq .Service "monolith" }}
+      ⚠️ **Deprecation Notice:** The monolithic package is deprecated in favor of the Azure family's
+      resource packages and will no longer be maintained after 12 June 2024. Please consider
+      switching to the [family provider packages](https://docs.upbound.io/providers/provider-families/)
+      as we will no longer be publishing new versions of the monolithic package.
+      \
+      {{ end }}
       Provider Azure is a Crossplane provider for [Microsoft Azure](https://azure.microsoft.com)
       developed and supported by Upbound.
       Available resources and their fields can be found in the [Upbound
       Marketplace](https://marketplace.upbound.io/providers/upbound/provider-{{ .ProviderName }}).
       If you encounter an issue please reach out on support@upbound.io email
       address. This is a subpackage for the {{ .Service }} API group.
-      {{ if eq .Service "monolith" }}
-      <br>
-      **Deprecation Notice:** The monolithic package is deprecated in favor of the Azure family's
-      resource packages and will no longer be maintained after 12 June 2024. Please consider
-      switching to the family provider packages as we will no longer be publishing new versions
-      of the monolithic package.
-      {{ end }}
     friendly-name.meta.crossplane.io: Provider Azure ({{ .Service }})
     auth.upbound.io/group: {{ .ProviderName }}.upbound.io
 spec:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
As we are approaching the end of support for the monolithic Azure package, this PR introduces:
- Info logs in the monolithic provider's output that communicate the deprecation and the next steps:
```shell
{"level":"info","ts":"2024-03-20T18:55:36+03:00","logger":"provider-azure","msg":"warning: The monolithic package is deprecated in favor of the Azure family's resource packages and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages as we will no longer be publishing new versions of the monolithic package.You can find more information about the provider families from the following link: https://docs.upbound.io/providers/provider-families/"}
```
- A deprecation message in the monolithic packages marketplace listing:
  - When the package readme is folded:
     <img width="1131" alt="image" src="https://github.com/crossplane-contrib/provider-upjet-azure/assets/9376684/41854e14-3f18-4820-9154-f4a0223176ee">
  - When it's expanded:
     <img width="1136" alt="image" src="https://github.com/crossplane-contrib/provider-upjet-azure/assets/9376684/8daf5166-8f67-423d-8027-03b6d0c7a4d5">

- No deprecation message in a resource provider's marketplace listing:
  <img width="1132" alt="image" src="https://github.com/crossplane-contrib/provider-upjet-azure/assets/9376684/3323ae47-9e1a-4634-8dd8-1159c093925c">


As the above screenshots show, the source repo URL is also updated to [github.com/crossplane-contrib/provider-upjet-azure](https://github.com/crossplane-contrib/provider-upjet-azure).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- Tested via the dev marketplace to check whether the deprecation message is properly displayed.
- Ran the monolithic provider to observe the warning message.
- Because we are introducing an emoji in the package metadata, I also wanted to see whether the Crossplane package manager can still properly process the metadata. Successfully installed `index.docker.io/ulucinar/provider-azure:v0.0.9` using UXP `1.15.1-up.1`.


[contribution process]: https://git.io/fj2m9
