### PR TITLE
docs: update marketplace link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ generation tools and exposes XRM-conformant managed resources for
 
 ## Getting Started
 
-Follow the quick start guide [here](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/docs/quickstart).
+Follow the quick start guide [here](https://marketplace.upbound.io/providers/upbound/provider-family-azure/latest/docs/quickstart).
 
-You can find a detailed API reference for all the managed resources with examples in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-azure/latest/managed-resources).
+You can find a detailed API reference for all the managed resources with examples in the [Upbound Marketplace](https://marketplace.upbound.io/providers/upbound/provider-family-azure/latest/managed-resources).
 
 For getting more information about resource consumption and monitoring
 the upjet runtime, please see [Sizing Guide](https://github.com/crossplane/upjet/blob/v0.10.0/docs/sizing-guide.md)


### PR DESCRIPTION
### Description of your changes
Simply updated the readme links from the deprecated monolithic provider to the family provider.
As both providers refer to this repo there was no direct path to the current provider.

I have:
- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

/ (docs change)