### PR TITLE
Use config.Reference.TerraformName instead of config.Reference.Type

### DIFF
--- a/apis/apimanagement/v1beta1/zz_apioperation_types.go
+++ b/apis/apimanagement/v1beta1/zz_apioperation_types.go
@@ -76,28 +76,28 @@ type APIOperationObservation struct {
 type APIOperationParameters struct {
 
 	// The Name of the API Management Service where the API exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The name of the API within the API Management Service where this API Operation should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIName *string `json:"apiName,omitempty" tf:"api_name,omitempty"`
 
-	// Reference to a API to populate apiName.
+	// Reference to a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameRef *v1.Reference `json:"apiNameRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiName.
+	// Selector for a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameSelector *v1.Selector `json:"apiNameSelector,omitempty" tf:"-"`
 

--- a/apis/apimanagement/v1beta1/zz_apipolicy_types.go
+++ b/apis/apimanagement/v1beta1/zz_apipolicy_types.go
@@ -46,28 +46,28 @@ type APIPolicyObservation struct {
 type APIPolicyParameters struct {
 
 	// The name of the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The ID of the API Management API within the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIName *string `json:"apiName,omitempty" tf:"api_name,omitempty"`
 
-	// Reference to a API to populate apiName.
+	// Reference to a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameRef *v1.Reference `json:"apiNameRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiName.
+	// Selector for a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameSelector *v1.Selector `json:"apiNameSelector,omitempty" tf:"-"`
 

--- a/apis/apimanagement/v1beta1/zz_apischema_types.go
+++ b/apis/apimanagement/v1beta1/zz_apischema_types.go
@@ -58,28 +58,28 @@ type APISchemaObservation struct {
 type APISchemaParameters struct {
 
 	// The Name of the API Management Service where the API exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The name of the API within the API Management Service where this API Schema should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIName *string `json:"apiName,omitempty" tf:"api_name,omitempty"`
 
-	// Reference to a API to populate apiName.
+	// Reference to a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameRef *v1.Reference `json:"apiNameRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiName.
+	// Selector for a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameSelector *v1.Selector `json:"apiNameSelector,omitempty" tf:"-"`
 

--- a/apis/apimanagement/v1beta1/zz_authorizationserver_types.go
+++ b/apis/apimanagement/v1beta1/zz_authorizationserver_types.go
@@ -123,15 +123,15 @@ type AuthorizationServerObservation struct {
 type AuthorizationServerParameters struct {
 
 	// The name of the API Management Service in which this Authorization Server should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 

--- a/apis/apimanagement/v1beta1/zz_gatewayapi_types.go
+++ b/apis/apimanagement/v1beta1/zz_gatewayapi_types.go
@@ -16,28 +16,28 @@ import (
 type GatewayAPIInitParameters struct {
 
 	// The Identifier of the API Management API within the API Management Service. Changing this forces a new API Management Gateway API to be created.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.API
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apimanagement to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apimanagement to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
 	// The Identifier for the API Management Gateway. Changing this forces a new API Management Gateway API to be created.
-	// +crossplane:generate:reference:type=Gateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Gateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	GatewayID *string `json:"gatewayId,omitempty" tf:"gateway_id,omitempty"`
 
-	// Reference to a Gateway to populate gatewayId.
+	// Reference to a Gateway in apimanagement to populate gatewayId.
 	// +kubebuilder:validation:Optional
 	GatewayIDRef *v1.Reference `json:"gatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a Gateway to populate gatewayId.
+	// Selector for a Gateway in apimanagement to populate gatewayId.
 	// +kubebuilder:validation:Optional
 	GatewayIDSelector *v1.Selector `json:"gatewayIdSelector,omitempty" tf:"-"`
 }
@@ -57,30 +57,30 @@ type GatewayAPIObservation struct {
 type GatewayAPIParameters struct {
 
 	// The Identifier of the API Management API within the API Management Service. Changing this forces a new API Management Gateway API to be created.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.API
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apimanagement to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apimanagement to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
 	// The Identifier for the API Management Gateway. Changing this forces a new API Management Gateway API to be created.
-	// +crossplane:generate:reference:type=Gateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Gateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	GatewayID *string `json:"gatewayId,omitempty" tf:"gateway_id,omitempty"`
 
-	// Reference to a Gateway to populate gatewayId.
+	// Reference to a Gateway in apimanagement to populate gatewayId.
 	// +kubebuilder:validation:Optional
 	GatewayIDRef *v1.Reference `json:"gatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a Gateway to populate gatewayId.
+	// Selector for a Gateway in apimanagement to populate gatewayId.
 	// +kubebuilder:validation:Optional
 	GatewayIDSelector *v1.Selector `json:"gatewayIdSelector,omitempty" tf:"-"`
 }

--- a/apis/apimanagement/v1beta1/zz_productapi_types.go
+++ b/apis/apimanagement/v1beta1/zz_productapi_types.go
@@ -37,41 +37,41 @@ type ProductAPIObservation struct {
 type ProductAPIParameters struct {
 
 	// The name of the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The Name of the API Management API within the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIName *string `json:"apiName,omitempty" tf:"api_name,omitempty"`
 
-	// Reference to a API to populate apiName.
+	// Reference to a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameRef *v1.Reference `json:"apiNameRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiName.
+	// Selector for a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameSelector *v1.Selector `json:"apiNameSelector,omitempty" tf:"-"`
 
 	// The ID of the API Management Product within the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Product
 	// +kubebuilder:validation:Optional
 	ProductID *string `json:"productId,omitempty" tf:"product_id,omitempty"`
 
-	// Reference to a Product to populate productId.
+	// Reference to a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDRef *v1.Reference `json:"productIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate productId.
+	// Selector for a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDSelector *v1.Selector `json:"productIdSelector,omitempty" tf:"-"`
 

--- a/apis/apimanagement/v1beta1/zz_productpolicy_types.go
+++ b/apis/apimanagement/v1beta1/zz_productpolicy_types.go
@@ -46,28 +46,28 @@ type ProductPolicyObservation struct {
 type ProductPolicyParameters struct {
 
 	// The name of the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The ID of the API Management Product within the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Product
 	// +kubebuilder:validation:Optional
 	ProductID *string `json:"productId,omitempty" tf:"product_id,omitempty"`
 
-	// Reference to a Product to populate productId.
+	// Reference to a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDRef *v1.Reference `json:"productIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate productId.
+	// Selector for a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDSelector *v1.Selector `json:"productIdSelector,omitempty" tf:"-"`
 

--- a/apis/apimanagement/v1beta1/zz_subscription_types.go
+++ b/apis/apimanagement/v1beta1/zz_subscription_types.go
@@ -22,15 +22,15 @@ type SubscriptionInitParameters struct {
 	AllowTracing *bool `json:"allowTracing,omitempty" tf:"allow_tracing,omitempty"`
 
 	// The ID of the Product which should be assigned to this Subscription. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Product
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ProductID *string `json:"productId,omitempty" tf:"product_id,omitempty"`
 
-	// Reference to a Product to populate productId.
+	// Reference to a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDRef *v1.Reference `json:"productIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate productId.
+	// Selector for a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDSelector *v1.Selector `json:"productIdSelector,omitempty" tf:"-"`
 
@@ -41,15 +41,15 @@ type SubscriptionInitParameters struct {
 	SubscriptionID *string `json:"subscriptionId,omitempty" tf:"subscription_id,omitempty"`
 
 	// The ID of the User which should be assigned to this Subscription. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.User
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	UserID *string `json:"userId,omitempty" tf:"user_id,omitempty"`
 
-	// Reference to a User to populate userId.
+	// Reference to a User in apimanagement to populate userId.
 	// +kubebuilder:validation:Optional
 	UserIDRef *v1.Reference `json:"userIdRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate userId.
+	// Selector for a User in apimanagement to populate userId.
 	// +kubebuilder:validation:Optional
 	UserIDSelector *v1.Selector `json:"userIdSelector,omitempty" tf:"-"`
 }
@@ -91,15 +91,15 @@ type SubscriptionParameters struct {
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
 	// The name of the API Management Service where this Subscription should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Management
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a Management to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a Management to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
@@ -112,16 +112,16 @@ type SubscriptionParameters struct {
 	PrimaryKeySecretRef *v1.SecretKeySelector `json:"primaryKeySecretRef,omitempty" tf:"-"`
 
 	// The ID of the Product which should be assigned to this Subscription. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.Product
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ProductID *string `json:"productId,omitempty" tf:"product_id,omitempty"`
 
-	// Reference to a Product to populate productId.
+	// Reference to a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDRef *v1.Reference `json:"productIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate productId.
+	// Selector for a Product in apimanagement to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDSelector *v1.Selector `json:"productIdSelector,omitempty" tf:"-"`
 
@@ -151,16 +151,16 @@ type SubscriptionParameters struct {
 	SubscriptionID *string `json:"subscriptionId,omitempty" tf:"subscription_id,omitempty"`
 
 	// The ID of the User which should be assigned to this Subscription. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/apimanagement/v1beta1.User
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	UserID *string `json:"userId,omitempty" tf:"user_id,omitempty"`
 
-	// Reference to a User to populate userId.
+	// Reference to a User in apimanagement to populate userId.
 	// +kubebuilder:validation:Optional
 	UserIDRef *v1.Reference `json:"userIdRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate userId.
+	// Selector for a User in apimanagement to populate userId.
 	// +kubebuilder:validation:Optional
 	UserIDSelector *v1.Selector `json:"userIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cache/v1beta1/zz_redislinkedserver_types.go
+++ b/apis/cache/v1beta1/zz_redislinkedserver_types.go
@@ -16,15 +16,15 @@ import (
 type RedisLinkedServerInitParameters struct {
 
 	// The ID of the linked Redis cache. Changing this forces a new Redis to be created.
-	// +crossplane:generate:reference:type=RedisCache
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cache/v1beta1.RedisCache
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	LinkedRedisCacheID *string `json:"linkedRedisCacheId,omitempty" tf:"linked_redis_cache_id,omitempty"`
 
-	// Reference to a RedisCache to populate linkedRedisCacheId.
+	// Reference to a RedisCache in cache to populate linkedRedisCacheId.
 	// +kubebuilder:validation:Optional
 	LinkedRedisCacheIDRef *v1.Reference `json:"linkedRedisCacheIdRef,omitempty" tf:"-"`
 
-	// Selector for a RedisCache to populate linkedRedisCacheId.
+	// Selector for a RedisCache in cache to populate linkedRedisCacheId.
 	// +kubebuilder:validation:Optional
 	LinkedRedisCacheIDSelector *v1.Selector `json:"linkedRedisCacheIdSelector,omitempty" tf:"-"`
 
@@ -65,16 +65,16 @@ type RedisLinkedServerObservation struct {
 type RedisLinkedServerParameters struct {
 
 	// The ID of the linked Redis cache. Changing this forces a new Redis to be created.
-	// +crossplane:generate:reference:type=RedisCache
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cache/v1beta1.RedisCache
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LinkedRedisCacheID *string `json:"linkedRedisCacheId,omitempty" tf:"linked_redis_cache_id,omitempty"`
 
-	// Reference to a RedisCache to populate linkedRedisCacheId.
+	// Reference to a RedisCache in cache to populate linkedRedisCacheId.
 	// +kubebuilder:validation:Optional
 	LinkedRedisCacheIDRef *v1.Reference `json:"linkedRedisCacheIdRef,omitempty" tf:"-"`
 
-	// Selector for a RedisCache to populate linkedRedisCacheId.
+	// Selector for a RedisCache in cache to populate linkedRedisCacheId.
 	// +kubebuilder:validation:Optional
 	LinkedRedisCacheIDSelector *v1.Selector `json:"linkedRedisCacheIdSelector,omitempty" tf:"-"`
 
@@ -100,15 +100,15 @@ type RedisLinkedServerParameters struct {
 	ServerRole *string `json:"serverRole,omitempty" tf:"server_role,omitempty"`
 
 	// The name of Redis cache to link with. Changing this forces a new Redis to be created. (eg The primary role)
-	// +crossplane:generate:reference:type=RedisCache
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cache/v1beta1.RedisCache
 	// +kubebuilder:validation:Optional
 	TargetRedisCacheName *string `json:"targetRedisCacheName,omitempty" tf:"target_redis_cache_name,omitempty"`
 
-	// Reference to a RedisCache to populate targetRedisCacheName.
+	// Reference to a RedisCache in cache to populate targetRedisCacheName.
 	// +kubebuilder:validation:Optional
 	TargetRedisCacheNameRef *v1.Reference `json:"targetRedisCacheNameRef,omitempty" tf:"-"`
 
-	// Selector for a RedisCache to populate targetRedisCacheName.
+	// Selector for a RedisCache in cache to populate targetRedisCacheName.
 	// +kubebuilder:validation:Optional
 	TargetRedisCacheNameSelector *v1.Selector `json:"targetRedisCacheNameSelector,omitempty" tf:"-"`
 }

--- a/apis/containerregistry/v1beta1/zz_containerconnectedregistry_types.go
+++ b/apis/containerregistry/v1beta1/zz_containerconnectedregistry_types.go
@@ -22,15 +22,15 @@ type ContainerConnectedRegistryInitParameters struct {
 	ClientTokenIds []*string `json:"clientTokenIds,omitempty" tf:"client_token_ids,omitempty"`
 
 	// The ID of the Container Registry that this Connected Registry will reside in. Changing this forces a new Container Connected Registry to be created.
-	// +crossplane:generate:reference:type=Registry
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerregistry/v1beta1.Registry
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ContainerRegistryID *string `json:"containerRegistryId,omitempty" tf:"container_registry_id,omitempty"`
 
-	// Reference to a Registry to populate containerRegistryId.
+	// Reference to a Registry in containerregistry to populate containerRegistryId.
 	// +kubebuilder:validation:Optional
 	ContainerRegistryIDRef *v1.Reference `json:"containerRegistryIdRef,omitempty" tf:"-"`
 
-	// Selector for a Registry to populate containerRegistryId.
+	// Selector for a Registry in containerregistry to populate containerRegistryId.
 	// +kubebuilder:validation:Optional
 	ContainerRegistryIDSelector *v1.Selector `json:"containerRegistryIdSelector,omitempty" tf:"-"`
 
@@ -53,15 +53,15 @@ type ContainerConnectedRegistryInitParameters struct {
 	SyncSchedule *string `json:"syncSchedule,omitempty" tf:"sync_schedule,omitempty"`
 
 	// The ID of the Container Registry Token which is used for synchronizing the Connected Registry. Changing this forces a new Container Connected Registry to be created.
-	// +crossplane:generate:reference:type=Token
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerregistry/v1beta1.Token
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SyncTokenID *string `json:"syncTokenId,omitempty" tf:"sync_token_id,omitempty"`
 
-	// Reference to a Token to populate syncTokenId.
+	// Reference to a Token in containerregistry to populate syncTokenId.
 	// +kubebuilder:validation:Optional
 	SyncTokenIDRef *v1.Reference `json:"syncTokenIdRef,omitempty" tf:"-"`
 
-	// Selector for a Token to populate syncTokenId.
+	// Selector for a Token in containerregistry to populate syncTokenId.
 	// +kubebuilder:validation:Optional
 	SyncTokenIDSelector *v1.Selector `json:"syncTokenIdSelector,omitempty" tf:"-"`
 
@@ -119,16 +119,16 @@ type ContainerConnectedRegistryParameters struct {
 	ClientTokenIds []*string `json:"clientTokenIds,omitempty" tf:"client_token_ids,omitempty"`
 
 	// The ID of the Container Registry that this Connected Registry will reside in. Changing this forces a new Container Connected Registry to be created.
-	// +crossplane:generate:reference:type=Registry
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerregistry/v1beta1.Registry
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ContainerRegistryID *string `json:"containerRegistryId,omitempty" tf:"container_registry_id,omitempty"`
 
-	// Reference to a Registry to populate containerRegistryId.
+	// Reference to a Registry in containerregistry to populate containerRegistryId.
 	// +kubebuilder:validation:Optional
 	ContainerRegistryIDRef *v1.Reference `json:"containerRegistryIdRef,omitempty" tf:"-"`
 
-	// Selector for a Registry to populate containerRegistryId.
+	// Selector for a Registry in containerregistry to populate containerRegistryId.
 	// +kubebuilder:validation:Optional
 	ContainerRegistryIDSelector *v1.Selector `json:"containerRegistryIdSelector,omitempty" tf:"-"`
 
@@ -157,16 +157,16 @@ type ContainerConnectedRegistryParameters struct {
 	SyncSchedule *string `json:"syncSchedule,omitempty" tf:"sync_schedule,omitempty"`
 
 	// The ID of the Container Registry Token which is used for synchronizing the Connected Registry. Changing this forces a new Container Connected Registry to be created.
-	// +crossplane:generate:reference:type=Token
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerregistry/v1beta1.Token
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SyncTokenID *string `json:"syncTokenId,omitempty" tf:"sync_token_id,omitempty"`
 
-	// Reference to a Token to populate syncTokenId.
+	// Reference to a Token in containerregistry to populate syncTokenId.
 	// +kubebuilder:validation:Optional
 	SyncTokenIDRef *v1.Reference `json:"syncTokenIdRef,omitempty" tf:"-"`
 
-	// Selector for a Token to populate syncTokenId.
+	// Selector for a Token in containerregistry to populate syncTokenId.
 	// +kubebuilder:validation:Optional
 	SyncTokenIDSelector *v1.Selector `json:"syncTokenIdSelector,omitempty" tf:"-"`
 

--- a/apis/containerregistry/v1beta1/zz_token_types.go
+++ b/apis/containerregistry/v1beta1/zz_token_types.go
@@ -19,15 +19,15 @@ type TokenInitParameters struct {
 	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
 	// The ID of the Container Registry Scope Map associated with the token.
-	// +crossplane:generate:reference:type=ScopeMap
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerregistry/v1beta1.ScopeMap
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ScopeMapID *string `json:"scopeMapId,omitempty" tf:"scope_map_id,omitempty"`
 
-	// Reference to a ScopeMap to populate scopeMapId.
+	// Reference to a ScopeMap in containerregistry to populate scopeMapId.
 	// +kubebuilder:validation:Optional
 	ScopeMapIDRef *v1.Reference `json:"scopeMapIdRef,omitempty" tf:"-"`
 
-	// Selector for a ScopeMap to populate scopeMapId.
+	// Selector for a ScopeMap in containerregistry to populate scopeMapId.
 	// +kubebuilder:validation:Optional
 	ScopeMapIDSelector *v1.Selector `json:"scopeMapIdSelector,omitempty" tf:"-"`
 }
@@ -83,16 +83,16 @@ type TokenParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The ID of the Container Registry Scope Map associated with the token.
-	// +crossplane:generate:reference:type=ScopeMap
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerregistry/v1beta1.ScopeMap
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ScopeMapID *string `json:"scopeMapId,omitempty" tf:"scope_map_id,omitempty"`
 
-	// Reference to a ScopeMap to populate scopeMapId.
+	// Reference to a ScopeMap in containerregistry to populate scopeMapId.
 	// +kubebuilder:validation:Optional
 	ScopeMapIDRef *v1.Reference `json:"scopeMapIdRef,omitempty" tf:"-"`
 
-	// Selector for a ScopeMap to populate scopeMapId.
+	// Selector for a ScopeMap in containerregistry to populate scopeMapId.
 	// +kubebuilder:validation:Optional
 	ScopeMapIDSelector *v1.Selector `json:"scopeMapIdSelector,omitempty" tf:"-"`
 }

--- a/apis/containerservice/v1beta1/zz_kubernetesclusternodepool_types.go
+++ b/apis/containerservice/v1beta1/zz_kubernetesclusternodepool_types.go
@@ -547,16 +547,16 @@ type KubernetesClusterNodePoolParameters struct {
 	KubeletDiskType *string `json:"kubeletDiskType,omitempty" tf:"kubelet_disk_type,omitempty"`
 
 	// The ID of the Kubernetes Cluster where this Node Pool should exist. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=KubernetesCluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/containerservice/v1beta1.KubernetesCluster
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KubernetesClusterID *string `json:"kubernetesClusterId,omitempty" tf:"kubernetes_cluster_id,omitempty"`
 
-	// Reference to a KubernetesCluster to populate kubernetesClusterId.
+	// Reference to a KubernetesCluster in containerservice to populate kubernetesClusterId.
 	// +kubebuilder:validation:Optional
 	KubernetesClusterIDRef *v1.Reference `json:"kubernetesClusterIdRef,omitempty" tf:"-"`
 
-	// Selector for a KubernetesCluster to populate kubernetesClusterId.
+	// Selector for a KubernetesCluster in containerservice to populate kubernetesClusterId.
 	// +kubebuilder:validation:Optional
 	KubernetesClusterIDSelector *v1.Selector `json:"kubernetesClusterIdSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_account_types.go
+++ b/apis/cosmosdb/v1beta1/zz_account_types.go
@@ -730,15 +730,15 @@ type RestoreInitParameters struct {
 	RestoreTimestampInUtc *string `json:"restoreTimestampInUtc,omitempty" tf:"restore_timestamp_in_utc,omitempty"`
 
 	// The resource ID of the restorable database account from which the restore has to be initiated. The example is /subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/restorableDatabaseAccounts/{restorableDatabaseAccountName}. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SourceCosmosDBAccountID *string `json:"sourceCosmosdbAccountId,omitempty" tf:"source_cosmosdb_account_id,omitempty"`
 
-	// Reference to a Account to populate sourceCosmosdbAccountId.
+	// Reference to a Account in cosmosdb to populate sourceCosmosdbAccountId.
 	// +kubebuilder:validation:Optional
 	SourceCosmosDBAccountIDRef *v1.Reference `json:"sourceCosmosdbAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate sourceCosmosdbAccountId.
+	// Selector for a Account in cosmosdb to populate sourceCosmosdbAccountId.
 	// +kubebuilder:validation:Optional
 	SourceCosmosDBAccountIDSelector *v1.Selector `json:"sourceCosmosdbAccountIdSelector,omitempty" tf:"-"`
 
@@ -779,16 +779,16 @@ type RestoreParameters struct {
 	RestoreTimestampInUtc *string `json:"restoreTimestampInUtc" tf:"restore_timestamp_in_utc,omitempty"`
 
 	// The resource ID of the restorable database account from which the restore has to be initiated. The example is /subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/restorableDatabaseAccounts/{restorableDatabaseAccountName}. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SourceCosmosDBAccountID *string `json:"sourceCosmosdbAccountId,omitempty" tf:"source_cosmosdb_account_id,omitempty"`
 
-	// Reference to a Account to populate sourceCosmosdbAccountId.
+	// Reference to a Account in cosmosdb to populate sourceCosmosdbAccountId.
 	// +kubebuilder:validation:Optional
 	SourceCosmosDBAccountIDRef *v1.Reference `json:"sourceCosmosdbAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate sourceCosmosdbAccountId.
+	// Selector for a Account in cosmosdb to populate sourceCosmosdbAccountId.
 	// +kubebuilder:validation:Optional
 	SourceCosmosDBAccountIDSelector *v1.Selector `json:"sourceCosmosdbAccountIdSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_cassandratable_types.go
+++ b/apis/cosmosdb/v1beta1/zz_cassandratable_types.go
@@ -85,16 +85,16 @@ type CassandraTableParameters struct {
 	AutoscaleSettings []CassandraTableAutoscaleSettingsParameters `json:"autoscaleSettings,omitempty" tf:"autoscale_settings,omitempty"`
 
 	// The ID of the Cosmos DB Cassandra Keyspace to create the table within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=CassandraKeySpace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.CassandraKeySpace
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CassandraKeySpaceID *string `json:"cassandraKeyspaceId,omitempty" tf:"cassandra_keyspace_id,omitempty"`
 
-	// Reference to a CassandraKeySpace to populate cassandraKeyspaceId.
+	// Reference to a CassandraKeySpace in cosmosdb to populate cassandraKeyspaceId.
 	// +kubebuilder:validation:Optional
 	CassandraKeySpaceIDRef *v1.Reference `json:"cassandraKeyspaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a CassandraKeySpace to populate cassandraKeyspaceId.
+	// Selector for a CassandraKeySpace in cosmosdb to populate cassandraKeyspaceId.
 	// +kubebuilder:validation:Optional
 	CassandraKeySpaceIDSelector *v1.Selector `json:"cassandraKeyspaceIdSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_gremlindatabase_types.go
+++ b/apis/cosmosdb/v1beta1/zz_gremlindatabase_types.go
@@ -62,15 +62,15 @@ type GremlinDatabaseObservation_2 struct {
 type GremlinDatabaseParameters_2 struct {
 
 	// The name of the CosmosDB Account to create the Gremlin Database within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_gremlingraph_types.go
+++ b/apis/cosmosdb/v1beta1/zz_gremlingraph_types.go
@@ -165,15 +165,15 @@ type GremlinGraphObservation struct {
 type GremlinGraphParameters struct {
 
 	// The name of the CosmosDB Account to create the Gremlin Graph within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 
@@ -190,15 +190,15 @@ type GremlinGraphParameters struct {
 	ConflictResolutionPolicy []ConflictResolutionPolicyParameters `json:"conflictResolutionPolicy,omitempty" tf:"conflict_resolution_policy,omitempty"`
 
 	// The name of the Cosmos DB Graph Database in which the Cosmos DB Gremlin Graph is created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=GremlinDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.GremlinDatabase
 	// +kubebuilder:validation:Optional
 	DatabaseName *string `json:"databaseName,omitempty" tf:"database_name,omitempty"`
 
-	// Reference to a GremlinDatabase to populate databaseName.
+	// Reference to a GremlinDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameRef *v1.Reference `json:"databaseNameRef,omitempty" tf:"-"`
 
-	// Selector for a GremlinDatabase to populate databaseName.
+	// Selector for a GremlinDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameSelector *v1.Selector `json:"databaseNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_mongocollection_types.go
+++ b/apis/cosmosdb/v1beta1/zz_mongocollection_types.go
@@ -121,15 +121,15 @@ type MongoCollectionObservation struct {
 type MongoCollectionParameters struct {
 
 	// The name of the Cosmos DB Account in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 
@@ -142,15 +142,15 @@ type MongoCollectionParameters struct {
 	AutoscaleSettings []MongoCollectionAutoscaleSettingsParameters `json:"autoscaleSettings,omitempty" tf:"autoscale_settings,omitempty"`
 
 	// The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MongoDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.MongoDatabase
 	// +kubebuilder:validation:Optional
 	DatabaseName *string `json:"databaseName,omitempty" tf:"database_name,omitempty"`
 
-	// Reference to a MongoDatabase to populate databaseName.
+	// Reference to a MongoDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameRef *v1.Reference `json:"databaseNameRef,omitempty" tf:"-"`
 
-	// Selector for a MongoDatabase to populate databaseName.
+	// Selector for a MongoDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameSelector *v1.Selector `json:"databaseNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_mongodatabase_types.go
+++ b/apis/cosmosdb/v1beta1/zz_mongodatabase_types.go
@@ -62,15 +62,15 @@ type MongoDatabaseObservation struct {
 type MongoDatabaseParameters struct {
 
 	// The name of the Cosmos DB Mongo Database to create the table within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_sqlcontainer_types.go
+++ b/apis/cosmosdb/v1beta1/zz_sqlcontainer_types.go
@@ -314,15 +314,15 @@ type SQLContainerObservation struct {
 type SQLContainerParameters struct {
 
 	// The name of the Cosmos DB Account to create the container within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 
@@ -339,15 +339,15 @@ type SQLContainerParameters struct {
 	ConflictResolutionPolicy []SQLContainerConflictResolutionPolicyParameters `json:"conflictResolutionPolicy,omitempty" tf:"conflict_resolution_policy,omitempty"`
 
 	// The name of the Cosmos DB SQL Database to create the container within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SQLDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.SQLDatabase
 	// +kubebuilder:validation:Optional
 	DatabaseName *string `json:"databaseName,omitempty" tf:"database_name,omitempty"`
 
-	// Reference to a SQLDatabase to populate databaseName.
+	// Reference to a SQLDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameRef *v1.Reference `json:"databaseNameRef,omitempty" tf:"-"`
 
-	// Selector for a SQLDatabase to populate databaseName.
+	// Selector for a SQLDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameSelector *v1.Selector `json:"databaseNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_sqldatabase_types.go
+++ b/apis/cosmosdb/v1beta1/zz_sqldatabase_types.go
@@ -62,15 +62,15 @@ type SQLDatabaseObservation struct {
 type SQLDatabaseParameters struct {
 
 	// The name of the Cosmos DB SQL Database to create the table within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_sqlfunction_types.go
+++ b/apis/cosmosdb/v1beta1/zz_sqlfunction_types.go
@@ -38,16 +38,16 @@ type SQLFunctionParameters struct {
 	Body *string `json:"body,omitempty" tf:"body,omitempty"`
 
 	// The id of the Cosmos DB SQL Container to create the SQL User Defined Function within. Changing this forces a new SQL User Defined Function to be created.
-	// +crossplane:generate:reference:type=SQLContainer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.SQLContainer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ContainerID *string `json:"containerId,omitempty" tf:"container_id,omitempty"`
 
-	// Reference to a SQLContainer to populate containerId.
+	// Reference to a SQLContainer in cosmosdb to populate containerId.
 	// +kubebuilder:validation:Optional
 	ContainerIDRef *v1.Reference `json:"containerIdRef,omitempty" tf:"-"`
 
-	// Selector for a SQLContainer to populate containerId.
+	// Selector for a SQLContainer in cosmosdb to populate containerId.
 	// +kubebuilder:validation:Optional
 	ContainerIDSelector *v1.Selector `json:"containerIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cosmosdb/v1beta1/zz_sqlstoredprocedure_types.go
+++ b/apis/cosmosdb/v1beta1/zz_sqlstoredprocedure_types.go
@@ -43,15 +43,15 @@ type SQLStoredProcedureObservation struct {
 type SQLStoredProcedureParameters struct {
 
 	// The name of the Cosmos DB Account to create the stored procedure within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 
@@ -60,28 +60,28 @@ type SQLStoredProcedureParameters struct {
 	Body *string `json:"body,omitempty" tf:"body,omitempty"`
 
 	// The name of the Cosmos DB SQL Container to create the stored procedure within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SQLContainer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.SQLContainer
 	// +kubebuilder:validation:Optional
 	ContainerName *string `json:"containerName,omitempty" tf:"container_name,omitempty"`
 
-	// Reference to a SQLContainer to populate containerName.
+	// Reference to a SQLContainer in cosmosdb to populate containerName.
 	// +kubebuilder:validation:Optional
 	ContainerNameRef *v1.Reference `json:"containerNameRef,omitempty" tf:"-"`
 
-	// Selector for a SQLContainer to populate containerName.
+	// Selector for a SQLContainer in cosmosdb to populate containerName.
 	// +kubebuilder:validation:Optional
 	ContainerNameSelector *v1.Selector `json:"containerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Cosmos DB SQL Database to create the stored procedure within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SQLDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.SQLDatabase
 	// +kubebuilder:validation:Optional
 	DatabaseName *string `json:"databaseName,omitempty" tf:"database_name,omitempty"`
 
-	// Reference to a SQLDatabase to populate databaseName.
+	// Reference to a SQLDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameRef *v1.Reference `json:"databaseNameRef,omitempty" tf:"-"`
 
-	// Selector for a SQLDatabase to populate databaseName.
+	// Selector for a SQLDatabase in cosmosdb to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameSelector *v1.Selector `json:"databaseNameSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_sqltrigger_types.go
+++ b/apis/cosmosdb/v1beta1/zz_sqltrigger_types.go
@@ -50,16 +50,16 @@ type SQLTriggerParameters struct {
 	Body *string `json:"body,omitempty" tf:"body,omitempty"`
 
 	// The id of the Cosmos DB SQL Container to create the SQL Trigger within. Changing this forces a new SQL Trigger to be created.
-	// +crossplane:generate:reference:type=SQLContainer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.SQLContainer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ContainerID *string `json:"containerId,omitempty" tf:"container_id,omitempty"`
 
-	// Reference to a SQLContainer to populate containerId.
+	// Reference to a SQLContainer in cosmosdb to populate containerId.
 	// +kubebuilder:validation:Optional
 	ContainerIDRef *v1.Reference `json:"containerIdRef,omitempty" tf:"-"`
 
-	// Selector for a SQLContainer to populate containerId.
+	// Selector for a SQLContainer in cosmosdb to populate containerId.
 	// +kubebuilder:validation:Optional
 	ContainerIDSelector *v1.Selector `json:"containerIdSelector,omitempty" tf:"-"`
 

--- a/apis/cosmosdb/v1beta1/zz_table_types.go
+++ b/apis/cosmosdb/v1beta1/zz_table_types.go
@@ -62,15 +62,15 @@ type TableObservation struct {
 type TableParameters struct {
 
 	// The name of the Cosmos DB Table to create the table within. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cosmosdb/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in cosmosdb to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 

--- a/apis/dataprotection/v1beta1/zz_backuppolicyblobstorage_types.go
+++ b/apis/dataprotection/v1beta1/zz_backuppolicyblobstorage_types.go
@@ -38,16 +38,16 @@ type BackupPolicyBlobStorageParameters struct {
 	RetentionDuration *string `json:"retentionDuration,omitempty" tf:"retention_duration,omitempty"`
 
 	// The ID of the Backup Vault within which the Backup Policy Blob Storage should exist. Changing this forces a new Backup Policy Blob Storage to be created.
-	// +crossplane:generate:reference:type=BackupVault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dataprotection/v1beta1.BackupVault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VaultID *string `json:"vaultId,omitempty" tf:"vault_id,omitempty"`
 
-	// Reference to a BackupVault to populate vaultId.
+	// Reference to a BackupVault in dataprotection to populate vaultId.
 	// +kubebuilder:validation:Optional
 	VaultIDRef *v1.Reference `json:"vaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a BackupVault to populate vaultId.
+	// Selector for a BackupVault in dataprotection to populate vaultId.
 	// +kubebuilder:validation:Optional
 	VaultIDSelector *v1.Selector `json:"vaultIdSelector,omitempty" tf:"-"`
 }

--- a/apis/dataprotection/v1beta1/zz_backuppolicydisk_types.go
+++ b/apis/dataprotection/v1beta1/zz_backuppolicydisk_types.go
@@ -68,16 +68,16 @@ type BackupPolicyDiskParameters struct {
 	TimeZone *string `json:"timeZone,omitempty" tf:"time_zone,omitempty"`
 
 	// The ID of the Backup Vault within which the Backup Policy Disk should exist. Changing this forces a new Backup Policy Disk to be created.
-	// +crossplane:generate:reference:type=BackupVault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dataprotection/v1beta1.BackupVault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VaultID *string `json:"vaultId,omitempty" tf:"vault_id,omitempty"`
 
-	// Reference to a BackupVault to populate vaultId.
+	// Reference to a BackupVault in dataprotection to populate vaultId.
 	// +kubebuilder:validation:Optional
 	VaultIDRef *v1.Reference `json:"vaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a BackupVault to populate vaultId.
+	// Selector for a BackupVault in dataprotection to populate vaultId.
 	// +kubebuilder:validation:Optional
 	VaultIDSelector *v1.Selector `json:"vaultIdSelector,omitempty" tf:"-"`
 }

--- a/apis/dataprotection/v1beta1/zz_backuppolicypostgresql_types.go
+++ b/apis/dataprotection/v1beta1/zz_backuppolicypostgresql_types.go
@@ -84,15 +84,15 @@ type BackupPolicyPostgreSQLParameters struct {
 	TimeZone *string `json:"timeZone,omitempty" tf:"time_zone,omitempty"`
 
 	// The name of the Backup Vault where the Backup Policy PostgreSQL should exist. Changing this forces a new Backup Policy PostgreSQL to be created.
-	// +crossplane:generate:reference:type=BackupVault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dataprotection/v1beta1.BackupVault
 	// +kubebuilder:validation:Optional
 	VaultName *string `json:"vaultName,omitempty" tf:"vault_name,omitempty"`
 
-	// Reference to a BackupVault to populate vaultName.
+	// Reference to a BackupVault in dataprotection to populate vaultName.
 	// +kubebuilder:validation:Optional
 	VaultNameRef *v1.Reference `json:"vaultNameRef,omitempty" tf:"-"`
 
-	// Selector for a BackupVault to populate vaultName.
+	// Selector for a BackupVault in dataprotection to populate vaultName.
 	// +kubebuilder:validation:Optional
 	VaultNameSelector *v1.Selector `json:"vaultNameSelector,omitempty" tf:"-"`
 }

--- a/apis/datashare/v1beta1/zz_datasetblobstorage_types.go
+++ b/apis/datashare/v1beta1/zz_datasetblobstorage_types.go
@@ -77,16 +77,16 @@ type DataSetBlobStorageParameters struct {
 	ContainerNameSelector *v1.Selector `json:"containerNameSelector,omitempty" tf:"-"`
 
 	// The ID of the Data Share in which this Data Share Blob Storage Dataset should be created. Changing this forces a new Data Share Blob Storage Dataset to be created.
-	// +crossplane:generate:reference:type=DataShare
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/datashare/v1beta1.DataShare
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	DataShareID *string `json:"dataShareId,omitempty" tf:"data_share_id,omitempty"`
 
-	// Reference to a DataShare to populate dataShareId.
+	// Reference to a DataShare in datashare to populate dataShareId.
 	// +kubebuilder:validation:Optional
 	DataShareIDRef *v1.Reference `json:"dataShareIdRef,omitempty" tf:"-"`
 
-	// Selector for a DataShare to populate dataShareId.
+	// Selector for a DataShare in datashare to populate dataShareId.
 	// +kubebuilder:validation:Optional
 	DataShareIDSelector *v1.Selector `json:"dataShareIdSelector,omitempty" tf:"-"`
 

--- a/apis/datashare/v1beta1/zz_datasetdatalakegen2_types.go
+++ b/apis/datashare/v1beta1/zz_datasetdatalakegen2_types.go
@@ -95,16 +95,16 @@ type DataSetDataLakeGen2Parameters struct {
 	FolderPath *string `json:"folderPath,omitempty" tf:"folder_path,omitempty"`
 
 	// The resource ID of the Data Share where this Data Share Data Lake Gen2 Dataset should be created. Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
-	// +crossplane:generate:reference:type=DataShare
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/datashare/v1beta1.DataShare
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ShareID *string `json:"shareId,omitempty" tf:"share_id,omitempty"`
 
-	// Reference to a DataShare to populate shareId.
+	// Reference to a DataShare in datashare to populate shareId.
 	// +kubebuilder:validation:Optional
 	ShareIDRef *v1.Reference `json:"shareIdRef,omitempty" tf:"-"`
 
-	// Selector for a DataShare to populate shareId.
+	// Selector for a DataShare in datashare to populate shareId.
 	// +kubebuilder:validation:Optional
 	ShareIDSelector *v1.Selector `json:"shareIdSelector,omitempty" tf:"-"`
 

--- a/apis/datashare/v1beta1/zz_datasetkustocluster_types.go
+++ b/apis/datashare/v1beta1/zz_datasetkustocluster_types.go
@@ -64,16 +64,16 @@ type DataSetKustoClusterParameters struct {
 	KustoClusterIDSelector *v1.Selector `json:"kustoClusterIdSelector,omitempty" tf:"-"`
 
 	// The resource ID of the Data Share where this Data Share Kusto Cluster Dataset should be created. Changing this forces a new Data Share Kusto Cluster Dataset to be created.
-	// +crossplane:generate:reference:type=DataShare
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/datashare/v1beta1.DataShare
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ShareID *string `json:"shareId,omitempty" tf:"share_id,omitempty"`
 
-	// Reference to a DataShare to populate shareId.
+	// Reference to a DataShare in datashare to populate shareId.
 	// +kubebuilder:validation:Optional
 	ShareIDRef *v1.Reference `json:"shareIdRef,omitempty" tf:"-"`
 
-	// Selector for a DataShare to populate shareId.
+	// Selector for a DataShare in datashare to populate shareId.
 	// +kubebuilder:validation:Optional
 	ShareIDSelector *v1.Selector `json:"shareIdSelector,omitempty" tf:"-"`
 }

--- a/apis/datashare/v1beta1/zz_datasetkustodatabase_types.go
+++ b/apis/datashare/v1beta1/zz_datasetkustodatabase_types.go
@@ -64,16 +64,16 @@ type DataSetKustoDatabaseParameters struct {
 	KustoDatabaseIDSelector *v1.Selector `json:"kustoDatabaseIdSelector,omitempty" tf:"-"`
 
 	// The resource ID of the Data Share where this Data Share Kusto Database Dataset should be created. Changing this forces a new Data Share Kusto Database Dataset to be created.
-	// +crossplane:generate:reference:type=DataShare
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/datashare/v1beta1.DataShare
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ShareID *string `json:"shareId,omitempty" tf:"share_id,omitempty"`
 
-	// Reference to a DataShare to populate shareId.
+	// Reference to a DataShare in datashare to populate shareId.
 	// +kubebuilder:validation:Optional
 	ShareIDRef *v1.Reference `json:"shareIdRef,omitempty" tf:"-"`
 
-	// Selector for a DataShare to populate shareId.
+	// Selector for a DataShare in datashare to populate shareId.
 	// +kubebuilder:validation:Optional
 	ShareIDSelector *v1.Selector `json:"shareIdSelector,omitempty" tf:"-"`
 }

--- a/apis/datashare/v1beta1/zz_datashare_types.go
+++ b/apis/datashare/v1beta1/zz_datashare_types.go
@@ -52,16 +52,16 @@ type DataShareObservation struct {
 type DataShareParameters struct {
 
 	// The ID of the Data Share account in which the Data Share is created. Changing this forces a new Data Share to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/datashare/v1beta1.Account
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	AccountID *string `json:"accountId,omitempty" tf:"account_id,omitempty"`
 
-	// Reference to a Account to populate accountId.
+	// Reference to a Account in datashare to populate accountId.
 	// +kubebuilder:validation:Optional
 	AccountIDRef *v1.Reference `json:"accountIdRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountId.
+	// Selector for a Account in datashare to populate accountId.
 	// +kubebuilder:validation:Optional
 	AccountIDSelector *v1.Selector `json:"accountIdSelector,omitempty" tf:"-"`
 

--- a/apis/dbformariadb/v1beta1/zz_firewallrule_types.go
+++ b/apis/dbformariadb/v1beta1/zz_firewallrule_types.go
@@ -60,15 +60,15 @@ type FirewallRuleParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the MariaDB Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbformariadb/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbformariadb to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbformariadb to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbformariadb/v1beta1/zz_server_types.go
+++ b/apis/dbformariadb/v1beta1/zz_server_types.go
@@ -28,15 +28,15 @@ type ServerInitParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// For creation modes other than Default, the source server ID to use.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbformariadb/v1beta1.Server
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	CreationSourceServerID *string `json:"creationSourceServerId,omitempty" tf:"creation_source_server_id,omitempty"`
 
-	// Reference to a Server to populate creationSourceServerId.
+	// Reference to a Server in dbformariadb to populate creationSourceServerId.
 	// +kubebuilder:validation:Optional
 	CreationSourceServerIDRef *v1.Reference `json:"creationSourceServerIdRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate creationSourceServerId.
+	// Selector for a Server in dbformariadb to populate creationSourceServerId.
 	// +kubebuilder:validation:Optional
 	CreationSourceServerIDSelector *v1.Selector `json:"creationSourceServerIdSelector,omitempty" tf:"-"`
 
@@ -153,16 +153,16 @@ type ServerParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// For creation modes other than Default, the source server ID to use.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbformariadb/v1beta1.Server
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CreationSourceServerID *string `json:"creationSourceServerId,omitempty" tf:"creation_source_server_id,omitempty"`
 
-	// Reference to a Server to populate creationSourceServerId.
+	// Reference to a Server in dbformariadb to populate creationSourceServerId.
 	// +kubebuilder:validation:Optional
 	CreationSourceServerIDRef *v1.Reference `json:"creationSourceServerIdRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate creationSourceServerId.
+	// Selector for a Server in dbformariadb to populate creationSourceServerId.
 	// +kubebuilder:validation:Optional
 	CreationSourceServerIDSelector *v1.Selector `json:"creationSourceServerIdSelector,omitempty" tf:"-"`
 

--- a/apis/dbformysql/v1beta1/zz_flexibledatabase_types.go
+++ b/apis/dbformysql/v1beta1/zz_flexibledatabase_types.go
@@ -64,15 +64,15 @@ type FlexibleDatabaseParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the MySQL Flexible Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbformysql/v1beta1.FlexibleServer
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverName.
+	// Reference to a FlexibleServer in dbformysql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverName.
+	// Selector for a FlexibleServer in dbformysql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 }

--- a/apis/dbformysql/v1beta1/zz_flexibleserverconfiguration_types.go
+++ b/apis/dbformysql/v1beta1/zz_flexibleserverconfiguration_types.go
@@ -50,15 +50,15 @@ type FlexibleServerConfigurationParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the MySQL Flexible Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbformysql/v1beta1.FlexibleServer
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverName.
+	// Reference to a FlexibleServer in dbformysql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverName.
+	// Selector for a FlexibleServer in dbformysql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbformysql/v1beta1/zz_flexibleserverfirewallrule_types.go
+++ b/apis/dbformysql/v1beta1/zz_flexibleserverfirewallrule_types.go
@@ -60,15 +60,15 @@ type FlexibleServerFirewallRuleParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the MySQL Flexible Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbformysql/v1beta1.FlexibleServer
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverName.
+	// Reference to a FlexibleServer in dbformysql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverName.
+	// Selector for a FlexibleServer in dbformysql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_activedirectoryadministrator_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_activedirectoryadministrator_types.go
@@ -70,15 +70,15 @@ type ActiveDirectoryAdministratorParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The name of the PostgreSQL Server on which to set the administrator. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_configuration_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_configuration_types.go
@@ -31,14 +31,14 @@ type ConfigurationInitParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 
@@ -84,15 +84,15 @@ type ConfigurationParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_database_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_database_types.go
@@ -64,15 +64,15 @@ type DatabaseParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 }

--- a/apis/dbforpostgresql/v1beta1/zz_firewallrule_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_firewallrule_types.go
@@ -60,15 +60,15 @@ type FirewallRuleParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_flexibleserveractivedirectoryadministrator_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_flexibleserveractivedirectoryadministrator_types.go
@@ -77,15 +77,15 @@ type FlexibleServerActiveDirectoryAdministratorParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The name of the PostgreSQL Flexible Server on which to set the administrator. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.FlexibleServer
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverName.
+	// Reference to a FlexibleServer in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverName.
+	// Selector for a FlexibleServer in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_flexibleserverconfiguration_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_flexibleserverconfiguration_types.go
@@ -19,15 +19,15 @@ type FlexibleServerConfigurationInitParameters struct {
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// The ID of the PostgreSQL Flexible Server where we want to change configuration. Changing this forces a new PostgreSQL Flexible Server Configuration resource.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.FlexibleServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverId.
+	// Reference to a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverId.
+	// Selector for a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 
@@ -57,16 +57,16 @@ type FlexibleServerConfigurationParameters struct {
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// The ID of the PostgreSQL Flexible Server where we want to change configuration. Changing this forces a new PostgreSQL Flexible Server Configuration resource.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.FlexibleServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverId.
+	// Reference to a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverId.
+	// Selector for a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_flexibleserverdatabase_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_flexibleserverdatabase_types.go
@@ -48,16 +48,16 @@ type FlexibleServerDatabaseParameters struct {
 	Collation *string `json:"collation,omitempty" tf:"collation,omitempty"`
 
 	// The ID of the Azure PostgreSQL Flexible Server from which to create this PostgreSQL Flexible Server Database. Changing this forces a new Azure PostgreSQL Flexible Server Database to be created.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.FlexibleServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverId.
+	// Reference to a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverId.
+	// Selector for a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 }

--- a/apis/dbforpostgresql/v1beta1/zz_flexibleserverfirewallrule_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_flexibleserverfirewallrule_types.go
@@ -44,16 +44,16 @@ type FlexibleServerFirewallRuleParameters struct {
 	EndIPAddress *string `json:"endIpAddress,omitempty" tf:"end_ip_address,omitempty"`
 
 	// The ID of the PostgreSQL Flexible Server from which to create this PostgreSQL Flexible Server Firewall Rule. Changing this forces a new PostgreSQL Flexible Server Firewall Rule to be created.
-	// +crossplane:generate:reference:type=FlexibleServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.FlexibleServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a FlexibleServer to populate serverId.
+	// Reference to a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a FlexibleServer to populate serverId.
+	// Selector for a FlexibleServer in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 

--- a/apis/dbforpostgresql/v1beta1/zz_serverkey_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_serverkey_types.go
@@ -29,15 +29,15 @@ type ServerKeyInitParameters struct {
 	KeyVaultKeyIDSelector *v1.Selector `json:"keyVaultKeyIdSelector,omitempty" tf:"-"`
 
 	// The ID of the PostgreSQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a Server to populate serverId.
+	// Reference to a Server in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverId.
+	// Selector for a Server in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 }
@@ -71,16 +71,16 @@ type ServerKeyParameters struct {
 	KeyVaultKeyIDSelector *v1.Selector `json:"keyVaultKeyIdSelector,omitempty" tf:"-"`
 
 	// The ID of the PostgreSQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a Server to populate serverId.
+	// Reference to a Server in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverId.
+	// Selector for a Server in dbforpostgresql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 }

--- a/apis/dbforpostgresql/v1beta1/zz_virtualnetworkrule_types.go
+++ b/apis/dbforpostgresql/v1beta1/zz_virtualnetworkrule_types.go
@@ -70,15 +70,15 @@ type VirtualNetworkRuleParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The name of the SQL Server to which this PostgreSQL virtual network rule will be applied to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/dbforpostgresql/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a Server to populate serverName.
+	// Reference to a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverName.
+	// Selector for a Server in dbforpostgresql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/devices/v1beta1/zz_iothubconsumergroup_types.go
+++ b/apis/devices/v1beta1/zz_iothubconsumergroup_types.go
@@ -38,15 +38,15 @@ type IOTHubConsumerGroupParameters struct {
 	EventHubEndpointName *string `json:"eventhubEndpointName" tf:"eventhub_endpoint_name,omitempty"`
 
 	// The name of the IoT Hub. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=IOTHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/devices/v1beta1.IOTHub
 	// +kubebuilder:validation:Optional
 	IOTHubName *string `json:"iothubName,omitempty" tf:"iothub_name,omitempty"`
 
-	// Reference to a IOTHub to populate iothubName.
+	// Reference to a IOTHub in devices to populate iothubName.
 	// +kubebuilder:validation:Optional
 	IOTHubNameRef *v1.Reference `json:"iothubNameRef,omitempty" tf:"-"`
 
-	// Selector for a IOTHub to populate iothubName.
+	// Selector for a IOTHub in devices to populate iothubName.
 	// +kubebuilder:validation:Optional
 	IOTHubNameSelector *v1.Selector `json:"iothubNameSelector,omitempty" tf:"-"`
 

--- a/apis/devices/v1beta1/zz_iothubdpscertificate_types.go
+++ b/apis/devices/v1beta1/zz_iothubdpscertificate_types.go
@@ -16,14 +16,14 @@ import (
 type IOTHubDPSCertificateInitParameters struct {
 
 	// The name of the IoT Device Provisioning Service that this certificate will be attached to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=IOTHubDPS
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/devices/v1beta1.IOTHubDPS
 	IOTDPSName *string `json:"iotDpsName,omitempty" tf:"iot_dps_name,omitempty"`
 
-	// Reference to a IOTHubDPS to populate iotDpsName.
+	// Reference to a IOTHubDPS in devices to populate iotDpsName.
 	// +kubebuilder:validation:Optional
 	IOTDPSNameRef *v1.Reference `json:"iotDpsNameRef,omitempty" tf:"-"`
 
-	// Selector for a IOTHubDPS to populate iotDpsName.
+	// Selector for a IOTHubDPS in devices to populate iotDpsName.
 	// +kubebuilder:validation:Optional
 	IOTDPSNameSelector *v1.Selector `json:"iotDpsNameSelector,omitempty" tf:"-"`
 
@@ -53,15 +53,15 @@ type IOTHubDPSCertificateParameters struct {
 	CertificateContentSecretRef v1.SecretKeySelector `json:"certificateContentSecretRef" tf:"-"`
 
 	// The name of the IoT Device Provisioning Service that this certificate will be attached to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=IOTHubDPS
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/devices/v1beta1.IOTHubDPS
 	// +kubebuilder:validation:Optional
 	IOTDPSName *string `json:"iotDpsName,omitempty" tf:"iot_dps_name,omitempty"`
 
-	// Reference to a IOTHubDPS to populate iotDpsName.
+	// Reference to a IOTHubDPS in devices to populate iotDpsName.
 	// +kubebuilder:validation:Optional
 	IOTDPSNameRef *v1.Reference `json:"iotDpsNameRef,omitempty" tf:"-"`
 
-	// Selector for a IOTHubDPS to populate iotDpsName.
+	// Selector for a IOTHubDPS in devices to populate iotDpsName.
 	// +kubebuilder:validation:Optional
 	IOTDPSNameSelector *v1.Selector `json:"iotDpsNameSelector,omitempty" tf:"-"`
 

--- a/apis/devices/v1beta1/zz_iothubfallbackroute_types.go
+++ b/apis/devices/v1beta1/zz_iothubfallbackroute_types.go
@@ -22,14 +22,14 @@ type IOTHubFallbackRouteInitParameters struct {
 	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
 	// The endpoints to which messages that satisfy the condition are routed. Currently only 1 endpoint is allowed.
-	// +crossplane:generate:reference:type=IOTHubEndpointStorageContainer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/devices/v1beta1.IOTHubEndpointStorageContainer
 	EndpointNames []*string `json:"endpointNames,omitempty" tf:"endpoint_names,omitempty"`
 
-	// References to IOTHubEndpointStorageContainer to populate endpointNames.
+	// References to IOTHubEndpointStorageContainer in devices to populate endpointNames.
 	// +kubebuilder:validation:Optional
 	EndpointNamesRefs []v1.Reference `json:"endpointNamesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of IOTHubEndpointStorageContainer to populate endpointNames.
+	// Selector for a list of IOTHubEndpointStorageContainer in devices to populate endpointNames.
 	// +kubebuilder:validation:Optional
 	EndpointNamesSelector *v1.Selector `json:"endpointNamesSelector,omitempty" tf:"-"`
 
@@ -72,28 +72,28 @@ type IOTHubFallbackRouteParameters struct {
 	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
 	// The endpoints to which messages that satisfy the condition are routed. Currently only 1 endpoint is allowed.
-	// +crossplane:generate:reference:type=IOTHubEndpointStorageContainer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/devices/v1beta1.IOTHubEndpointStorageContainer
 	// +kubebuilder:validation:Optional
 	EndpointNames []*string `json:"endpointNames,omitempty" tf:"endpoint_names,omitempty"`
 
-	// References to IOTHubEndpointStorageContainer to populate endpointNames.
+	// References to IOTHubEndpointStorageContainer in devices to populate endpointNames.
 	// +kubebuilder:validation:Optional
 	EndpointNamesRefs []v1.Reference `json:"endpointNamesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of IOTHubEndpointStorageContainer to populate endpointNames.
+	// Selector for a list of IOTHubEndpointStorageContainer in devices to populate endpointNames.
 	// +kubebuilder:validation:Optional
 	EndpointNamesSelector *v1.Selector `json:"endpointNamesSelector,omitempty" tf:"-"`
 
 	// The name of the IoTHub to which this Fallback Route belongs. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=IOTHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/devices/v1beta1.IOTHub
 	// +kubebuilder:validation:Optional
 	IOTHubName *string `json:"iothubName,omitempty" tf:"iothub_name,omitempty"`
 
-	// Reference to a IOTHub to populate iothubName.
+	// Reference to a IOTHub in devices to populate iothubName.
 	// +kubebuilder:validation:Optional
 	IOTHubNameRef *v1.Reference `json:"iothubNameRef,omitempty" tf:"-"`
 
-	// Selector for a IOTHub to populate iothubName.
+	// Selector for a IOTHub in devices to populate iothubName.
 	// +kubebuilder:validation:Optional
 	IOTHubNameSelector *v1.Selector `json:"iothubNameSelector,omitempty" tf:"-"`
 

--- a/apis/eventhub/v1beta1/zz_authorizationrule_types.go
+++ b/apis/eventhub/v1beta1/zz_authorizationrule_types.go
@@ -52,15 +52,15 @@ type AuthorizationRuleObservation struct {
 type AuthorizationRuleParameters struct {
 
 	// Specifies the name of the EventHub. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=EventHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/eventhub/v1beta1.EventHub
 	// +kubebuilder:validation:Optional
 	EventHubName *string `json:"eventhubName,omitempty" tf:"eventhub_name,omitempty"`
 
-	// Reference to a EventHub to populate eventhubName.
+	// Reference to a EventHub in eventhub to populate eventhubName.
 	// +kubebuilder:validation:Optional
 	EventHubNameRef *v1.Reference `json:"eventhubNameRef,omitempty" tf:"-"`
 
-	// Selector for a EventHub to populate eventhubName.
+	// Selector for a EventHub in eventhub to populate eventhubName.
 	// +kubebuilder:validation:Optional
 	EventHubNameSelector *v1.Selector `json:"eventhubNameSelector,omitempty" tf:"-"`
 
@@ -73,15 +73,15 @@ type AuthorizationRuleParameters struct {
 	Manage *bool `json:"manage,omitempty" tf:"manage,omitempty"`
 
 	// Specifies the name of the grandparent EventHub Namespace. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=EventHubNamespace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/eventhub/v1beta1.EventHubNamespace
 	// +kubebuilder:validation:Optional
 	NamespaceName *string `json:"namespaceName,omitempty" tf:"namespace_name,omitempty"`
 
-	// Reference to a EventHubNamespace to populate namespaceName.
+	// Reference to a EventHubNamespace in eventhub to populate namespaceName.
 	// +kubebuilder:validation:Optional
 	NamespaceNameRef *v1.Reference `json:"namespaceNameRef,omitempty" tf:"-"`
 
-	// Selector for a EventHubNamespace to populate namespaceName.
+	// Selector for a EventHubNamespace in eventhub to populate namespaceName.
 	// +kubebuilder:validation:Optional
 	NamespaceNameSelector *v1.Selector `json:"namespaceNameSelector,omitempty" tf:"-"`
 

--- a/apis/eventhub/v1beta1/zz_consumergroup_types.go
+++ b/apis/eventhub/v1beta1/zz_consumergroup_types.go
@@ -40,28 +40,28 @@ type ConsumerGroupObservation struct {
 type ConsumerGroupParameters struct {
 
 	// Specifies the name of the EventHub. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=EventHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/eventhub/v1beta1.EventHub
 	// +kubebuilder:validation:Optional
 	EventHubName *string `json:"eventhubName,omitempty" tf:"eventhub_name,omitempty"`
 
-	// Reference to a EventHub to populate eventhubName.
+	// Reference to a EventHub in eventhub to populate eventhubName.
 	// +kubebuilder:validation:Optional
 	EventHubNameRef *v1.Reference `json:"eventhubNameRef,omitempty" tf:"-"`
 
-	// Selector for a EventHub to populate eventhubName.
+	// Selector for a EventHub in eventhub to populate eventhubName.
 	// +kubebuilder:validation:Optional
 	EventHubNameSelector *v1.Selector `json:"eventhubNameSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the grandparent EventHub Namespace. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=EventHubNamespace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/eventhub/v1beta1.EventHubNamespace
 	// +kubebuilder:validation:Optional
 	NamespaceName *string `json:"namespaceName,omitempty" tf:"namespace_name,omitempty"`
 
-	// Reference to a EventHubNamespace to populate namespaceName.
+	// Reference to a EventHubNamespace in eventhub to populate namespaceName.
 	// +kubebuilder:validation:Optional
 	NamespaceNameRef *v1.Reference `json:"namespaceNameRef,omitempty" tf:"-"`
 
-	// Selector for a EventHubNamespace to populate namespaceName.
+	// Selector for a EventHubNamespace in eventhub to populate namespaceName.
 	// +kubebuilder:validation:Optional
 	NamespaceNameSelector *v1.Selector `json:"namespaceNameSelector,omitempty" tf:"-"`
 

--- a/apis/eventhub/v1beta1/zz_eventhub_types.go
+++ b/apis/eventhub/v1beta1/zz_eventhub_types.go
@@ -185,15 +185,15 @@ type EventHubParameters struct {
 	MessageRetention *float64 `json:"messageRetention,omitempty" tf:"message_retention,omitempty"`
 
 	// Specifies the name of the EventHub Namespace. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=EventHubNamespace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/eventhub/v1beta1.EventHubNamespace
 	// +kubebuilder:validation:Optional
 	NamespaceName *string `json:"namespaceName,omitempty" tf:"namespace_name,omitempty"`
 
-	// Reference to a EventHubNamespace to populate namespaceName.
+	// Reference to a EventHubNamespace in eventhub to populate namespaceName.
 	// +kubebuilder:validation:Optional
 	NamespaceNameRef *v1.Reference `json:"namespaceNameRef,omitempty" tf:"-"`
 
-	// Selector for a EventHubNamespace to populate namespaceName.
+	// Selector for a EventHubNamespace in eventhub to populate namespaceName.
 	// +kubebuilder:validation:Optional
 	NamespaceNameSelector *v1.Selector `json:"namespaceNameSelector,omitempty" tf:"-"`
 

--- a/apis/healthcareapis/v1beta1/zz_healthcaremedtechservice_types.go
+++ b/apis/healthcareapis/v1beta1/zz_healthcaremedtechservice_types.go
@@ -193,16 +193,16 @@ type HealthcareMedtechServiceParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the id of the Healthcare Workspace where the Healthcare Med Tech Service should exist. Changing this forces a new Healthcare Med Tech Service to be created.
-	// +crossplane:generate:reference:type=HealthcareWorkspace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/healthcareapis/v1beta1.HealthcareWorkspace
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	WorkspaceID *string `json:"workspaceId,omitempty" tf:"workspace_id,omitempty"`
 
-	// Reference to a HealthcareWorkspace to populate workspaceId.
+	// Reference to a HealthcareWorkspace in healthcareapis to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDRef *v1.Reference `json:"workspaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HealthcareWorkspace to populate workspaceId.
+	// Selector for a HealthcareWorkspace in healthcareapis to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDSelector *v1.Selector `json:"workspaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/healthcareapis/v1beta1/zz_healthcaremedtechservicefhirdestination_types.go
+++ b/apis/healthcareapis/v1beta1/zz_healthcaremedtechservicefhirdestination_types.go
@@ -19,15 +19,15 @@ type HealthcareMedtechServiceFHIRDestinationInitParameters struct {
 	DestinationFHIRMappingJSON *string `json:"destinationFhirMappingJson,omitempty" tf:"destination_fhir_mapping_json,omitempty"`
 
 	// Specifies the destination fhir service id of the Med Tech Service Fhir Destination.
-	// +crossplane:generate:reference:type=HealthcareFHIRService
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/healthcareapis/v1beta1.HealthcareFHIRService
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	DestinationFHIRServiceID *string `json:"destinationFhirServiceId,omitempty" tf:"destination_fhir_service_id,omitempty"`
 
-	// Reference to a HealthcareFHIRService to populate destinationFhirServiceId.
+	// Reference to a HealthcareFHIRService in healthcareapis to populate destinationFhirServiceId.
 	// +kubebuilder:validation:Optional
 	DestinationFHIRServiceIDRef *v1.Reference `json:"destinationFhirServiceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HealthcareFHIRService to populate destinationFhirServiceId.
+	// Selector for a HealthcareFHIRService in healthcareapis to populate destinationFhirServiceId.
 	// +kubebuilder:validation:Optional
 	DestinationFHIRServiceIDSelector *v1.Selector `json:"destinationFhirServiceIdSelector,omitempty" tf:"-"`
 
@@ -66,16 +66,16 @@ type HealthcareMedtechServiceFHIRDestinationParameters struct {
 	DestinationFHIRMappingJSON *string `json:"destinationFhirMappingJson,omitempty" tf:"destination_fhir_mapping_json,omitempty"`
 
 	// Specifies the destination fhir service id of the Med Tech Service Fhir Destination.
-	// +crossplane:generate:reference:type=HealthcareFHIRService
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/healthcareapis/v1beta1.HealthcareFHIRService
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	DestinationFHIRServiceID *string `json:"destinationFhirServiceId,omitempty" tf:"destination_fhir_service_id,omitempty"`
 
-	// Reference to a HealthcareFHIRService to populate destinationFhirServiceId.
+	// Reference to a HealthcareFHIRService in healthcareapis to populate destinationFhirServiceId.
 	// +kubebuilder:validation:Optional
 	DestinationFHIRServiceIDRef *v1.Reference `json:"destinationFhirServiceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HealthcareFHIRService to populate destinationFhirServiceId.
+	// Selector for a HealthcareFHIRService in healthcareapis to populate destinationFhirServiceId.
 	// +kubebuilder:validation:Optional
 	DestinationFHIRServiceIDSelector *v1.Selector `json:"destinationFhirServiceIdSelector,omitempty" tf:"-"`
 
@@ -88,16 +88,16 @@ type HealthcareMedtechServiceFHIRDestinationParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// Specifies the name of the Healthcare Med Tech Service where the Healthcare Med Tech Service Fhir Destination should exist. Changing this forces a new Healthcare Med Tech Service Fhir Destination to be created.
-	// +crossplane:generate:reference:type=HealthcareMedtechService
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/healthcareapis/v1beta1.HealthcareMedtechService
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	MedtechServiceID *string `json:"medtechServiceId,omitempty" tf:"medtech_service_id,omitempty"`
 
-	// Reference to a HealthcareMedtechService to populate medtechServiceId.
+	// Reference to a HealthcareMedtechService in healthcareapis to populate medtechServiceId.
 	// +kubebuilder:validation:Optional
 	MedtechServiceIDRef *v1.Reference `json:"medtechServiceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HealthcareMedtechService to populate medtechServiceId.
+	// Selector for a HealthcareMedtechService in healthcareapis to populate medtechServiceId.
 	// +kubebuilder:validation:Optional
 	MedtechServiceIDSelector *v1.Selector `json:"medtechServiceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/insights/v1beta1/zz_monitormetricalert_types.go
+++ b/apis/insights/v1beta1/zz_monitormetricalert_types.go
@@ -242,15 +242,15 @@ type DynamicCriteriaParameters struct {
 type MonitorMetricAlertActionInitParameters struct {
 
 	// The ID of the Action Group can be sourced from the
-	// +crossplane:generate:reference:type=MonitorActionGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ActionGroupID *string `json:"actionGroupId,omitempty" tf:"action_group_id,omitempty"`
 
-	// Reference to a MonitorActionGroup to populate actionGroupId.
+	// Reference to a MonitorActionGroup in insights to populate actionGroupId.
 	// +kubebuilder:validation:Optional
 	ActionGroupIDRef *v1.Reference `json:"actionGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a MonitorActionGroup to populate actionGroupId.
+	// Selector for a MonitorActionGroup in insights to populate actionGroupId.
 	// +kubebuilder:validation:Optional
 	ActionGroupIDSelector *v1.Selector `json:"actionGroupIdSelector,omitempty" tf:"-"`
 
@@ -272,16 +272,16 @@ type MonitorMetricAlertActionObservation struct {
 type MonitorMetricAlertActionParameters struct {
 
 	// The ID of the Action Group can be sourced from the
-	// +crossplane:generate:reference:type=MonitorActionGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ActionGroupID *string `json:"actionGroupId,omitempty" tf:"action_group_id,omitempty"`
 
-	// Reference to a MonitorActionGroup to populate actionGroupId.
+	// Reference to a MonitorActionGroup in insights to populate actionGroupId.
 	// +kubebuilder:validation:Optional
 	ActionGroupIDRef *v1.Reference `json:"actionGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a MonitorActionGroup to populate actionGroupId.
+	// Selector for a MonitorActionGroup in insights to populate actionGroupId.
 	// +kubebuilder:validation:Optional
 	ActionGroupIDSelector *v1.Selector `json:"actionGroupIdSelector,omitempty" tf:"-"`
 

--- a/apis/insights/v1beta1/zz_monitorprivatelinkscopedservice_types.go
+++ b/apis/insights/v1beta1/zz_monitorprivatelinkscopedservice_types.go
@@ -16,15 +16,15 @@ import (
 type MonitorPrivateLinkScopedServiceInitParameters struct {
 
 	// The ID of the linked resource. It must be the Log Analytics workspace or the Application Insights component or the Data Collection endpoint. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ApplicationInsights
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.ApplicationInsights
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	LinkedResourceID *string `json:"linkedResourceId,omitempty" tf:"linked_resource_id,omitempty"`
 
-	// Reference to a ApplicationInsights to populate linkedResourceId.
+	// Reference to a ApplicationInsights in insights to populate linkedResourceId.
 	// +kubebuilder:validation:Optional
 	LinkedResourceIDRef *v1.Reference `json:"linkedResourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a ApplicationInsights to populate linkedResourceId.
+	// Selector for a ApplicationInsights in insights to populate linkedResourceId.
 	// +kubebuilder:validation:Optional
 	LinkedResourceIDSelector *v1.Selector `json:"linkedResourceIdSelector,omitempty" tf:"-"`
 }
@@ -47,16 +47,16 @@ type MonitorPrivateLinkScopedServiceObservation struct {
 type MonitorPrivateLinkScopedServiceParameters struct {
 
 	// The ID of the linked resource. It must be the Log Analytics workspace or the Application Insights component or the Data Collection endpoint. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ApplicationInsights
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.ApplicationInsights
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LinkedResourceID *string `json:"linkedResourceId,omitempty" tf:"linked_resource_id,omitempty"`
 
-	// Reference to a ApplicationInsights to populate linkedResourceId.
+	// Reference to a ApplicationInsights in insights to populate linkedResourceId.
 	// +kubebuilder:validation:Optional
 	LinkedResourceIDRef *v1.Reference `json:"linkedResourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a ApplicationInsights to populate linkedResourceId.
+	// Selector for a ApplicationInsights in insights to populate linkedResourceId.
 	// +kubebuilder:validation:Optional
 	LinkedResourceIDSelector *v1.Selector `json:"linkedResourceIdSelector,omitempty" tf:"-"`
 
@@ -74,15 +74,15 @@ type MonitorPrivateLinkScopedServiceParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The name of the Azure Monitor Private Link Scope. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MonitorPrivateLinkScope
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorPrivateLinkScope
 	// +kubebuilder:validation:Optional
 	ScopeName *string `json:"scopeName,omitempty" tf:"scope_name,omitempty"`
 
-	// Reference to a MonitorPrivateLinkScope to populate scopeName.
+	// Reference to a MonitorPrivateLinkScope in insights to populate scopeName.
 	// +kubebuilder:validation:Optional
 	ScopeNameRef *v1.Reference `json:"scopeNameRef,omitempty" tf:"-"`
 
-	// Selector for a MonitorPrivateLinkScope to populate scopeName.
+	// Selector for a MonitorPrivateLinkScope in insights to populate scopeName.
 	// +kubebuilder:validation:Optional
 	ScopeNameSelector *v1.Selector `json:"scopeNameSelector,omitempty" tf:"-"`
 }

--- a/apis/insights/v1beta1/zz_monitorscheduledqueryrulesalert_types.go
+++ b/apis/insights/v1beta1/zz_monitorscheduledqueryrulesalert_types.go
@@ -16,16 +16,16 @@ import (
 type MonitorScheduledQueryRulesAlertActionInitParameters struct {
 
 	// List of action group reference resource IDs.
-	// +crossplane:generate:reference:type=MonitorActionGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +listType=set
 	ActionGroup []*string `json:"actionGroup,omitempty" tf:"action_group,omitempty"`
 
-	// References to MonitorActionGroup to populate actionGroup.
+	// References to MonitorActionGroup in insights to populate actionGroup.
 	// +kubebuilder:validation:Optional
 	ActionGroupRefs []v1.Reference `json:"actionGroupRefs,omitempty" tf:"-"`
 
-	// Selector for a list of MonitorActionGroup to populate actionGroup.
+	// Selector for a list of MonitorActionGroup in insights to populate actionGroup.
 	// +kubebuilder:validation:Optional
 	ActionGroupSelector *v1.Selector `json:"actionGroupSelector,omitempty" tf:"-"`
 
@@ -52,17 +52,17 @@ type MonitorScheduledQueryRulesAlertActionObservation struct {
 type MonitorScheduledQueryRulesAlertActionParameters struct {
 
 	// List of action group reference resource IDs.
-	// +crossplane:generate:reference:type=MonitorActionGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	ActionGroup []*string `json:"actionGroup,omitempty" tf:"action_group,omitempty"`
 
-	// References to MonitorActionGroup to populate actionGroup.
+	// References to MonitorActionGroup in insights to populate actionGroup.
 	// +kubebuilder:validation:Optional
 	ActionGroupRefs []v1.Reference `json:"actionGroupRefs,omitempty" tf:"-"`
 
-	// Selector for a list of MonitorActionGroup to populate actionGroup.
+	// Selector for a list of MonitorActionGroup in insights to populate actionGroup.
 	// +kubebuilder:validation:Optional
 	ActionGroupSelector *v1.Selector `json:"actionGroupSelector,omitempty" tf:"-"`
 

--- a/apis/insights/v1beta1/zz_monitorscheduledqueryrulesalertv2_types.go
+++ b/apis/insights/v1beta1/zz_monitorscheduledqueryrulesalertv2_types.go
@@ -235,15 +235,15 @@ type MonitorScheduledQueryRulesAlertV2InitParameters struct {
 	QueryTimeRangeOverride *string `json:"queryTimeRangeOverride,omitempty" tf:"query_time_range_override,omitempty"`
 
 	// Specifies the list of resource IDs that this scheduled query rule is scoped to. Changing this forces a new resource to be created. Currently, the API supports exactly 1 resource ID in the scopes list.
-	// +crossplane:generate:reference:type=ApplicationInsights
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.ApplicationInsights
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	Scopes []*string `json:"scopes,omitempty" tf:"scopes,omitempty"`
 
-	// References to ApplicationInsights to populate scopes.
+	// References to ApplicationInsights in insights to populate scopes.
 	// +kubebuilder:validation:Optional
 	ScopesRefs []v1.Reference `json:"scopesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of ApplicationInsights to populate scopes.
+	// Selector for a list of ApplicationInsights in insights to populate scopes.
 	// +kubebuilder:validation:Optional
 	ScopesSelector *v1.Selector `json:"scopesSelector,omitempty" tf:"-"`
 
@@ -393,16 +393,16 @@ type MonitorScheduledQueryRulesAlertV2Parameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// Specifies the list of resource IDs that this scheduled query rule is scoped to. Changing this forces a new resource to be created. Currently, the API supports exactly 1 resource ID in the scopes list.
-	// +crossplane:generate:reference:type=ApplicationInsights
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/insights/v1beta1.ApplicationInsights
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	Scopes []*string `json:"scopes,omitempty" tf:"scopes,omitempty"`
 
-	// References to ApplicationInsights to populate scopes.
+	// References to ApplicationInsights in insights to populate scopes.
 	// +kubebuilder:validation:Optional
 	ScopesRefs []v1.Reference `json:"scopesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of ApplicationInsights to populate scopes.
+	// Selector for a list of ApplicationInsights in insights to populate scopes.
 	// +kubebuilder:validation:Optional
 	ScopesSelector *v1.Selector `json:"scopesSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_accesspolicy_types.go
+++ b/apis/keyvault/v1beta1/zz_accesspolicy_types.go
@@ -25,15 +25,15 @@ type AccessPolicyInitParameters_2 struct {
 	KeyPermissions []*string `json:"keyPermissions,omitempty" tf:"key_permissions,omitempty"`
 
 	// Specifies the id of the Key Vault resource. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 
@@ -95,16 +95,16 @@ type AccessPolicyParameters_2 struct {
 	KeyPermissions []*string `json:"keyPermissions,omitempty" tf:"key_permissions,omitempty"`
 
 	// Specifies the id of the Key Vault resource. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_certificate_types.go
+++ b/apis/keyvault/v1beta1/zz_certificate_types.go
@@ -85,15 +85,15 @@ type CertificateInitParameters struct {
 	CertificatePolicy []CertificatePolicyInitParameters `json:"certificatePolicy,omitempty" tf:"certificate_policy,omitempty"`
 
 	// The ID of the Key Vault where the Certificate should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 
@@ -168,16 +168,16 @@ type CertificateParameters struct {
 	CertificatePolicy []CertificatePolicyParameters `json:"certificatePolicy,omitempty" tf:"certificate_policy,omitempty"`
 
 	// The ID of the Key Vault where the Certificate should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_certificateissuer_types.go
+++ b/apis/keyvault/v1beta1/zz_certificateissuer_types.go
@@ -71,15 +71,15 @@ type CertificateIssuerInitParameters struct {
 	Admin []AdminInitParameters `json:"admin,omitempty" tf:"admin,omitempty"`
 
 	// The ID of the Key Vault in which to create the Certificate Issuer. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 
@@ -122,16 +122,16 @@ type CertificateIssuerParameters struct {
 	Admin []AdminParameters `json:"admin,omitempty" tf:"admin,omitempty"`
 
 	// The ID of the Key Vault in which to create the Certificate Issuer. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_key_types.go
+++ b/apis/keyvault/v1beta1/zz_key_types.go
@@ -60,15 +60,15 @@ type KeyInitParameters struct {
 	KeyType *string `json:"keyType,omitempty" tf:"key_type,omitempty"`
 
 	// The ID of the Key Vault where the Key should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 
@@ -176,16 +176,16 @@ type KeyParameters struct {
 	KeyType *string `json:"keyType,omitempty" tf:"key_type,omitempty"`
 
 	// The ID of the Key Vault where the Key should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_managedstorageaccount_types.go
+++ b/apis/keyvault/v1beta1/zz_managedstorageaccount_types.go
@@ -16,15 +16,15 @@ import (
 type ManagedStorageAccountInitParameters struct {
 
 	// The ID of the Key Vault where the Managed Storage Account should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 
@@ -83,16 +83,16 @@ type ManagedStorageAccountObservation struct {
 type ManagedStorageAccountParameters struct {
 
 	// The ID of the Key Vault where the Managed Storage Account should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_managedstorageaccountsastokendefinition_types.go
+++ b/apis/keyvault/v1beta1/zz_managedstorageaccountsastokendefinition_types.go
@@ -57,16 +57,16 @@ type ManagedStorageAccountSASTokenDefinitionObservation struct {
 type ManagedStorageAccountSASTokenDefinitionParameters struct {
 
 	// The ID of the Managed Storage Account.
-	// +crossplane:generate:reference:type=ManagedStorageAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.ManagedStorageAccount
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ManagedStorageAccountID *string `json:"managedStorageAccountId,omitempty" tf:"managed_storage_account_id,omitempty"`
 
-	// Reference to a ManagedStorageAccount to populate managedStorageAccountId.
+	// Reference to a ManagedStorageAccount in keyvault to populate managedStorageAccountId.
 	// +kubebuilder:validation:Optional
 	ManagedStorageAccountIDRef *v1.Reference `json:"managedStorageAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a ManagedStorageAccount to populate managedStorageAccountId.
+	// Selector for a ManagedStorageAccount in keyvault to populate managedStorageAccountId.
 	// +kubebuilder:validation:Optional
 	ManagedStorageAccountIDSelector *v1.Selector `json:"managedStorageAccountIdSelector,omitempty" tf:"-"`
 

--- a/apis/keyvault/v1beta1/zz_secret_types.go
+++ b/apis/keyvault/v1beta1/zz_secret_types.go
@@ -22,15 +22,15 @@ type SecretInitParameters struct {
 	ExpirationDate *string `json:"expirationDate,omitempty" tf:"expiration_date,omitempty"`
 
 	// The ID of the Key Vault where the Secret should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 
@@ -93,16 +93,16 @@ type SecretParameters struct {
 	ExpirationDate *string `json:"expirationDate,omitempty" tf:"expiration_date,omitempty"`
 
 	// The ID of the Key Vault where the Secret should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/keyvault/v1beta1.Vault
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	KeyVaultID *string `json:"keyVaultId,omitempty" tf:"key_vault_id,omitempty"`
 
-	// Reference to a Vault to populate keyVaultId.
+	// Reference to a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDRef *v1.Reference `json:"keyVaultIdRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate keyVaultId.
+	// Selector for a Vault in keyvault to populate keyVaultId.
 	// +kubebuilder:validation:Optional
 	KeyVaultIDSelector *v1.Selector `json:"keyVaultIdSelector,omitempty" tf:"-"`
 

--- a/apis/kusto/v1beta1/zz_database_types.go
+++ b/apis/kusto/v1beta1/zz_database_types.go
@@ -52,15 +52,15 @@ type DatabaseObservation struct {
 type DatabaseParameters struct {
 
 	// Specifies the name of the Kusto Cluster this database will be added to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/kusto/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in kusto to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in kusto to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 

--- a/apis/management/v1beta1/zz_managementgroupsubscriptionassociation_types.go
+++ b/apis/management/v1beta1/zz_managementgroupsubscriptionassociation_types.go
@@ -16,15 +16,15 @@ import (
 type ManagementGroupSubscriptionAssociationInitParameters struct {
 
 	// The ID of the Management Group to associate the Subscription with. Changing this forces a new Management to be created.
-	// +crossplane:generate:reference:type=ManagementGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/management/v1beta1.ManagementGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ManagementGroupID *string `json:"managementGroupId,omitempty" tf:"management_group_id,omitempty"`
 
-	// Reference to a ManagementGroup to populate managementGroupId.
+	// Reference to a ManagementGroup in management to populate managementGroupId.
 	// +kubebuilder:validation:Optional
 	ManagementGroupIDRef *v1.Reference `json:"managementGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a ManagementGroup to populate managementGroupId.
+	// Selector for a ManagementGroup in management to populate managementGroupId.
 	// +kubebuilder:validation:Optional
 	ManagementGroupIDSelector *v1.Selector `json:"managementGroupIdSelector,omitempty" tf:"-"`
 
@@ -57,16 +57,16 @@ type ManagementGroupSubscriptionAssociationObservation struct {
 type ManagementGroupSubscriptionAssociationParameters struct {
 
 	// The ID of the Management Group to associate the Subscription with. Changing this forces a new Management to be created.
-	// +crossplane:generate:reference:type=ManagementGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/management/v1beta1.ManagementGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ManagementGroupID *string `json:"managementGroupId,omitempty" tf:"management_group_id,omitempty"`
 
-	// Reference to a ManagementGroup to populate managementGroupId.
+	// Reference to a ManagementGroup in management to populate managementGroupId.
 	// +kubebuilder:validation:Optional
 	ManagementGroupIDRef *v1.Reference `json:"managementGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a ManagementGroup to populate managementGroupId.
+	// Selector for a ManagementGroup in management to populate managementGroupId.
 	// +kubebuilder:validation:Optional
 	ManagementGroupIDSelector *v1.Selector `json:"managementGroupIdSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_asset_types.go
+++ b/apis/media/v1beta1/zz_asset_types.go
@@ -67,15 +67,15 @@ type AssetParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// Specifies the name of the Media Services Account. Changing this forces a new Media Asset to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_liveevent_types.go
+++ b/apis/media/v1beta1/zz_liveevent_types.go
@@ -313,15 +313,15 @@ type LiveEventParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The Media Services account name. Changing this forces a new Live Event to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_liveeventoutput_types.go
+++ b/apis/media/v1beta1/zz_liveeventoutput_types.go
@@ -19,14 +19,14 @@ type LiveEventOutputInitParameters struct {
 	ArchiveWindowDuration *string `json:"archiveWindowDuration,omitempty" tf:"archive_window_duration,omitempty"`
 
 	// The asset that the live output will write to. Changing this forces a new Live Output to be created.
-	// +crossplane:generate:reference:type=Asset
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.Asset
 	AssetName *string `json:"assetName,omitempty" tf:"asset_name,omitempty"`
 
-	// Reference to a Asset to populate assetName.
+	// Reference to a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameRef *v1.Reference `json:"assetNameRef,omitempty" tf:"-"`
 
-	// Selector for a Asset to populate assetName.
+	// Selector for a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameSelector *v1.Selector `json:"assetNameSelector,omitempty" tf:"-"`
 
@@ -83,15 +83,15 @@ type LiveEventOutputParameters struct {
 	ArchiveWindowDuration *string `json:"archiveWindowDuration,omitempty" tf:"archive_window_duration,omitempty"`
 
 	// The asset that the live output will write to. Changing this forces a new Live Output to be created.
-	// +crossplane:generate:reference:type=Asset
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.Asset
 	// +kubebuilder:validation:Optional
 	AssetName *string `json:"assetName,omitempty" tf:"asset_name,omitempty"`
 
-	// Reference to a Asset to populate assetName.
+	// Reference to a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameRef *v1.Reference `json:"assetNameRef,omitempty" tf:"-"`
 
-	// Selector for a Asset to populate assetName.
+	// Selector for a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameSelector *v1.Selector `json:"assetNameSelector,omitempty" tf:"-"`
 
@@ -104,16 +104,16 @@ type LiveEventOutputParameters struct {
 	HlsFragmentsPerTSSegment *float64 `json:"hlsFragmentsPerTsSegment,omitempty" tf:"hls_fragments_per_ts_segment,omitempty"`
 
 	// The id of the live event. Changing this forces a new Live Output to be created.
-	// +crossplane:generate:reference:type=LiveEvent
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.LiveEvent
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LiveEventID *string `json:"liveEventId,omitempty" tf:"live_event_id,omitempty"`
 
-	// Reference to a LiveEvent to populate liveEventId.
+	// Reference to a LiveEvent in media to populate liveEventId.
 	// +kubebuilder:validation:Optional
 	LiveEventIDRef *v1.Reference `json:"liveEventIdRef,omitempty" tf:"-"`
 
-	// Selector for a LiveEvent to populate liveEventId.
+	// Selector for a LiveEvent in media to populate liveEventId.
 	// +kubebuilder:validation:Optional
 	LiveEventIDSelector *v1.Selector `json:"liveEventIdSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_servicesaccountfilter_types.go
+++ b/apis/media/v1beta1/zz_servicesaccountfilter_types.go
@@ -53,15 +53,15 @@ type ServicesAccountFilterParameters struct {
 	FirstQualityBitrate *float64 `json:"firstQualityBitrate,omitempty" tf:"first_quality_bitrate,omitempty"`
 
 	// The Media Services account name. Changing this forces a new Account Filter to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_streamingendpoint_types.go
+++ b/apis/media/v1beta1/zz_streamingendpoint_types.go
@@ -305,15 +305,15 @@ type StreamingEndpointParameters struct {
 	MaxCacheAgeSeconds *float64 `json:"maxCacheAgeSeconds,omitempty" tf:"max_cache_age_seconds,omitempty"`
 
 	// The Media Services account name. Changing this forces a new Streaming Endpoint to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_streaminglocator_types.go
+++ b/apis/media/v1beta1/zz_streaminglocator_types.go
@@ -78,14 +78,14 @@ type StreamingLocatorInitParameters struct {
 	AlternativeMediaID *string `json:"alternativeMediaId,omitempty" tf:"alternative_media_id,omitempty"`
 
 	// Asset Name. Changing this forces a new Streaming Locator to be created.
-	// +crossplane:generate:reference:type=Asset
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.Asset
 	AssetName *string `json:"assetName,omitempty" tf:"asset_name,omitempty"`
 
-	// Reference to a Asset to populate assetName.
+	// Reference to a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameRef *v1.Reference `json:"assetNameRef,omitempty" tf:"-"`
 
-	// Selector for a Asset to populate assetName.
+	// Selector for a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameSelector *v1.Selector `json:"assetNameSelector,omitempty" tf:"-"`
 
@@ -157,15 +157,15 @@ type StreamingLocatorParameters struct {
 	AlternativeMediaID *string `json:"alternativeMediaId,omitempty" tf:"alternative_media_id,omitempty"`
 
 	// Asset Name. Changing this forces a new Streaming Locator to be created.
-	// +crossplane:generate:reference:type=Asset
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.Asset
 	// +kubebuilder:validation:Optional
 	AssetName *string `json:"assetName,omitempty" tf:"asset_name,omitempty"`
 
-	// Reference to a Asset to populate assetName.
+	// Reference to a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameRef *v1.Reference `json:"assetNameRef,omitempty" tf:"-"`
 
-	// Selector for a Asset to populate assetName.
+	// Selector for a Asset in media to populate assetName.
 	// +kubebuilder:validation:Optional
 	AssetNameSelector *v1.Selector `json:"assetNameSelector,omitempty" tf:"-"`
 
@@ -186,15 +186,15 @@ type StreamingLocatorParameters struct {
 	FilterNames []*string `json:"filterNames,omitempty" tf:"filter_names,omitempty"`
 
 	// The Media Services account name. Changing this forces a new Streaming Locator to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_streamingpolicy_types.go
+++ b/apis/media/v1beta1/zz_streamingpolicy_types.go
@@ -738,15 +738,15 @@ type StreamingPolicyParameters struct {
 	EnvelopeEncryption []EnvelopeEncryptionParameters `json:"envelopeEncryption,omitempty" tf:"envelope_encryption,omitempty"`
 
 	// The Media Services account name. Changing this forces a new Streaming Policy to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/media/v1beta1/zz_transform_types.go
+++ b/apis/media/v1beta1/zz_transform_types.go
@@ -1884,15 +1884,15 @@ type TransformParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The Media Services account name. Changing this forces a new Transform to be created.
-	// +crossplane:generate:reference:type=ServicesAccount
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/media/v1beta1.ServicesAccount
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountName *string `json:"mediaServicesAccountName,omitempty" tf:"media_services_account_name,omitempty"`
 
-	// Reference to a ServicesAccount to populate mediaServicesAccountName.
+	// Reference to a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameRef *v1.Reference `json:"mediaServicesAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a ServicesAccount to populate mediaServicesAccountName.
+	// Selector for a ServicesAccount in media to populate mediaServicesAccountName.
 	// +kubebuilder:validation:Optional
 	MediaServicesAccountNameSelector *v1.Selector `json:"mediaServicesAccountNameSelector,omitempty" tf:"-"`
 

--- a/apis/netapp/v1beta1/zz_pool_types.go
+++ b/apis/netapp/v1beta1/zz_pool_types.go
@@ -69,15 +69,15 @@ type PoolObservation struct {
 type PoolParameters struct {
 
 	// The name of the NetApp account in which the NetApp Pool should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 

--- a/apis/netapp/v1beta1/zz_snapshot_types.go
+++ b/apis/netapp/v1beta1/zz_snapshot_types.go
@@ -43,15 +43,15 @@ type SnapshotObservation struct {
 type SnapshotParameters struct {
 
 	// The name of the NetApp account in which the NetApp Pool should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 
@@ -60,15 +60,15 @@ type SnapshotParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The name of the NetApp pool in which the NetApp Volume should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Pool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Pool
 	// +kubebuilder:validation:Optional
 	PoolName *string `json:"poolName,omitempty" tf:"pool_name,omitempty"`
 
-	// Reference to a Pool to populate poolName.
+	// Reference to a Pool in netapp to populate poolName.
 	// +kubebuilder:validation:Optional
 	PoolNameRef *v1.Reference `json:"poolNameRef,omitempty" tf:"-"`
 
-	// Selector for a Pool to populate poolName.
+	// Selector for a Pool in netapp to populate poolName.
 	// +kubebuilder:validation:Optional
 	PoolNameSelector *v1.Selector `json:"poolNameSelector,omitempty" tf:"-"`
 
@@ -86,15 +86,15 @@ type SnapshotParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The name of the NetApp volume in which the NetApp Snapshot should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Volume
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Volume
 	// +kubebuilder:validation:Optional
 	VolumeName *string `json:"volumeName,omitempty" tf:"volume_name,omitempty"`
 
-	// Reference to a Volume to populate volumeName.
+	// Reference to a Volume in netapp to populate volumeName.
 	// +kubebuilder:validation:Optional
 	VolumeNameRef *v1.Reference `json:"volumeNameRef,omitempty" tf:"-"`
 
-	// Selector for a Volume to populate volumeName.
+	// Selector for a Volume in netapp to populate volumeName.
 	// +kubebuilder:validation:Optional
 	VolumeNameSelector *v1.Selector `json:"volumeNameSelector,omitempty" tf:"-"`
 }

--- a/apis/netapp/v1beta1/zz_snapshotpolicy_types.go
+++ b/apis/netapp/v1beta1/zz_snapshotpolicy_types.go
@@ -195,15 +195,15 @@ type SnapshotPolicyObservation struct {
 type SnapshotPolicyParameters struct {
 
 	// The name of the NetApp Account in which the NetApp Snapshot Policy should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 

--- a/apis/netapp/v1beta1/zz_volume_types.go
+++ b/apis/netapp/v1beta1/zz_volume_types.go
@@ -22,15 +22,15 @@ type DataProtectionReplicationInitParameters struct {
 	RemoteVolumeLocation *string `json:"remoteVolumeLocation,omitempty" tf:"remote_volume_location,omitempty"`
 
 	// Resource ID of the primary volume.
-	// +crossplane:generate:reference:type=Volume
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Volume
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	RemoteVolumeResourceID *string `json:"remoteVolumeResourceId,omitempty" tf:"remote_volume_resource_id,omitempty"`
 
-	// Reference to a Volume to populate remoteVolumeResourceId.
+	// Reference to a Volume in netapp to populate remoteVolumeResourceId.
 	// +kubebuilder:validation:Optional
 	RemoteVolumeResourceIDRef *v1.Reference `json:"remoteVolumeResourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Volume to populate remoteVolumeResourceId.
+	// Selector for a Volume in netapp to populate remoteVolumeResourceId.
 	// +kubebuilder:validation:Optional
 	RemoteVolumeResourceIDSelector *v1.Selector `json:"remoteVolumeResourceIdSelector,omitempty" tf:"-"`
 
@@ -64,16 +64,16 @@ type DataProtectionReplicationParameters struct {
 	RemoteVolumeLocation *string `json:"remoteVolumeLocation" tf:"remote_volume_location,omitempty"`
 
 	// Resource ID of the primary volume.
-	// +crossplane:generate:reference:type=Volume
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Volume
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	RemoteVolumeResourceID *string `json:"remoteVolumeResourceId,omitempty" tf:"remote_volume_resource_id,omitempty"`
 
-	// Reference to a Volume to populate remoteVolumeResourceId.
+	// Reference to a Volume in netapp to populate remoteVolumeResourceId.
 	// +kubebuilder:validation:Optional
 	RemoteVolumeResourceIDRef *v1.Reference `json:"remoteVolumeResourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Volume to populate remoteVolumeResourceId.
+	// Selector for a Volume in netapp to populate remoteVolumeResourceId.
 	// +kubebuilder:validation:Optional
 	RemoteVolumeResourceIDSelector *v1.Selector `json:"remoteVolumeResourceIdSelector,omitempty" tf:"-"`
 
@@ -85,15 +85,15 @@ type DataProtectionReplicationParameters struct {
 type DataProtectionSnapshotPolicyInitParameters struct {
 
 	// Resource ID of the snapshot policy to apply to the volume.
-	// +crossplane:generate:reference:type=SnapshotPolicy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.SnapshotPolicy
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SnapshotPolicyID *string `json:"snapshotPolicyId,omitempty" tf:"snapshot_policy_id,omitempty"`
 
-	// Reference to a SnapshotPolicy to populate snapshotPolicyId.
+	// Reference to a SnapshotPolicy in netapp to populate snapshotPolicyId.
 	// +kubebuilder:validation:Optional
 	SnapshotPolicyIDRef *v1.Reference `json:"snapshotPolicyIdRef,omitempty" tf:"-"`
 
-	// Selector for a SnapshotPolicy to populate snapshotPolicyId.
+	// Selector for a SnapshotPolicy in netapp to populate snapshotPolicyId.
 	// +kubebuilder:validation:Optional
 	SnapshotPolicyIDSelector *v1.Selector `json:"snapshotPolicyIdSelector,omitempty" tf:"-"`
 }
@@ -107,16 +107,16 @@ type DataProtectionSnapshotPolicyObservation struct {
 type DataProtectionSnapshotPolicyParameters struct {
 
 	// Resource ID of the snapshot policy to apply to the volume.
-	// +crossplane:generate:reference:type=SnapshotPolicy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.SnapshotPolicy
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SnapshotPolicyID *string `json:"snapshotPolicyId,omitempty" tf:"snapshot_policy_id,omitempty"`
 
-	// Reference to a SnapshotPolicy to populate snapshotPolicyId.
+	// Reference to a SnapshotPolicy in netapp to populate snapshotPolicyId.
 	// +kubebuilder:validation:Optional
 	SnapshotPolicyIDRef *v1.Reference `json:"snapshotPolicyIdRef,omitempty" tf:"-"`
 
-	// Selector for a SnapshotPolicy to populate snapshotPolicyId.
+	// Selector for a SnapshotPolicy in netapp to populate snapshotPolicyId.
 	// +kubebuilder:validation:Optional
 	SnapshotPolicyIDSelector *v1.Selector `json:"snapshotPolicyIdSelector,omitempty" tf:"-"`
 }
@@ -199,15 +199,15 @@ type VolumeInitParameters struct {
 	AzureVMwareDataStoreEnabled *bool `json:"azureVmwareDataStoreEnabled,omitempty" tf:"azure_vmware_data_store_enabled,omitempty"`
 
 	// Creates volume from snapshot. Following properties must be the same as the original volume where the snapshot was taken from: protocols, subnet_id, location, service_level, resource_group_name, account_name and pool_name. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Snapshot
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Snapshot
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	CreateFromSnapshotResourceID *string `json:"createFromSnapshotResourceId,omitempty" tf:"create_from_snapshot_resource_id,omitempty"`
 
-	// Reference to a Snapshot to populate createFromSnapshotResourceId.
+	// Reference to a Snapshot in netapp to populate createFromSnapshotResourceId.
 	// +kubebuilder:validation:Optional
 	CreateFromSnapshotResourceIDRef *v1.Reference `json:"createFromSnapshotResourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Snapshot to populate createFromSnapshotResourceId.
+	// Selector for a Snapshot in netapp to populate createFromSnapshotResourceId.
 	// +kubebuilder:validation:Optional
 	CreateFromSnapshotResourceIDSelector *v1.Selector `json:"createFromSnapshotResourceIdSelector,omitempty" tf:"-"`
 
@@ -367,15 +367,15 @@ type VolumeObservation struct {
 type VolumeParameters struct {
 
 	// The name of the NetApp account in which the NetApp Pool should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	AccountName *string `json:"accountName,omitempty" tf:"account_name,omitempty"`
 
-	// Reference to a Account to populate accountName.
+	// Reference to a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameRef *v1.Reference `json:"accountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate accountName.
+	// Selector for a Account in netapp to populate accountName.
 	// +kubebuilder:validation:Optional
 	AccountNameSelector *v1.Selector `json:"accountNameSelector,omitempty" tf:"-"`
 
@@ -384,16 +384,16 @@ type VolumeParameters struct {
 	AzureVMwareDataStoreEnabled *bool `json:"azureVmwareDataStoreEnabled,omitempty" tf:"azure_vmware_data_store_enabled,omitempty"`
 
 	// Creates volume from snapshot. Following properties must be the same as the original volume where the snapshot was taken from: protocols, subnet_id, location, service_level, resource_group_name, account_name and pool_name. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Snapshot
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Snapshot
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CreateFromSnapshotResourceID *string `json:"createFromSnapshotResourceId,omitempty" tf:"create_from_snapshot_resource_id,omitempty"`
 
-	// Reference to a Snapshot to populate createFromSnapshotResourceId.
+	// Reference to a Snapshot in netapp to populate createFromSnapshotResourceId.
 	// +kubebuilder:validation:Optional
 	CreateFromSnapshotResourceIDRef *v1.Reference `json:"createFromSnapshotResourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Snapshot to populate createFromSnapshotResourceId.
+	// Selector for a Snapshot in netapp to populate createFromSnapshotResourceId.
 	// +kubebuilder:validation:Optional
 	CreateFromSnapshotResourceIDSelector *v1.Selector `json:"createFromSnapshotResourceIdSelector,omitempty" tf:"-"`
 
@@ -426,15 +426,15 @@ type VolumeParameters struct {
 	NetworkFeatures *string `json:"networkFeatures,omitempty" tf:"network_features,omitempty"`
 
 	// The name of the NetApp pool in which the NetApp Volume should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Pool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/netapp/v1beta1.Pool
 	// +kubebuilder:validation:Optional
 	PoolName *string `json:"poolName,omitempty" tf:"pool_name,omitempty"`
 
-	// Reference to a Pool to populate poolName.
+	// Reference to a Pool in netapp to populate poolName.
 	// +kubebuilder:validation:Optional
 	PoolNameRef *v1.Reference `json:"poolNameRef,omitempty" tf:"-"`
 
-	// Selector for a Pool to populate poolName.
+	// Selector for a Pool in netapp to populate poolName.
 	// +kubebuilder:validation:Optional
 	PoolNameSelector *v1.Selector `json:"poolNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_applicationgateway_types.go
+++ b/apis/network/v1beta1/zz_applicationgateway_types.go
@@ -823,28 +823,28 @@ type FrontendIPConfigurationInitParameters struct {
 	PrivateLinkConfigurationName *string `json:"privateLinkConfigurationName,omitempty" tf:"private_link_configuration_name,omitempty"`
 
 	// The ID of a Public IP Address which the Application Gateway should use. The allocation method for the Public IP Address depends on the sku of this Application Gateway. Please refer to the Azure documentation for public IP addresses for details.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -895,30 +895,30 @@ type FrontendIPConfigurationParameters struct {
 	PrivateLinkConfigurationName *string `json:"privateLinkConfigurationName,omitempty" tf:"private_link_configuration_name,omitempty"`
 
 	// The ID of a Public IP Address which the Application Gateway should use. The allocation method for the Public IP Address depends on the sku of this Application Gateway. Please refer to the Azure documentation for public IP addresses for details.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -1220,15 +1220,15 @@ type IPConfigurationInitParameters struct {
 	PrivateIPAddressAllocation *string `json:"privateIpAddressAllocation,omitempty" tf:"private_ip_address_allocation,omitempty"`
 
 	// The ID of the subnet the private link configuration should connect to.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -1270,16 +1270,16 @@ type IPConfigurationParameters struct {
 	PrivateIPAddressAllocation *string `json:"privateIpAddressAllocation" tf:"private_ip_address_allocation,omitempty"`
 
 	// The ID of the subnet the private link configuration should connect to.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_connectionmonitor_types.go
+++ b/apis/network/v1beta1/zz_connectionmonitor_types.go
@@ -82,16 +82,16 @@ type ConnectionMonitorParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The ID of the Network Watcher. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Watcher
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Watcher
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkWatcherID *string `json:"networkWatcherId,omitempty" tf:"network_watcher_id,omitempty"`
 
-	// Reference to a Watcher to populate networkWatcherId.
+	// Reference to a Watcher in network to populate networkWatcherId.
 	// +kubebuilder:validation:Optional
 	NetworkWatcherIDRef *v1.Reference `json:"networkWatcherIdRef,omitempty" tf:"-"`
 
-	// Selector for a Watcher to populate networkWatcherId.
+	// Selector for a Watcher in network to populate networkWatcherId.
 	// +kubebuilder:validation:Optional
 	NetworkWatcherIDSelector *v1.Selector `json:"networkWatcherIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_dnsaaaarecord_types.go
+++ b/apis/network/v1beta1/zz_dnsaaaarecord_types.go
@@ -113,15 +113,15 @@ type DNSAAAARecordParameters struct {
 	TargetResourceIDSelector *v1.Selector `json:"targetResourceIdSelector,omitempty" tf:"-"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnsarecord_types.go
+++ b/apis/network/v1beta1/zz_dnsarecord_types.go
@@ -113,15 +113,15 @@ type DNSARecordParameters struct {
 	TargetResourceIDSelector *v1.Selector `json:"targetResourceIdSelector,omitempty" tf:"-"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnscaarecord_types.go
+++ b/apis/network/v1beta1/zz_dnscaarecord_types.go
@@ -80,15 +80,15 @@ type DNSCAARecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnscnamerecord_types.go
+++ b/apis/network/v1beta1/zz_dnscnamerecord_types.go
@@ -110,15 +110,15 @@ type DNSCNAMERecordParameters struct {
 	TargetResourceIDSelector *v1.Selector `json:"targetResourceIdSelector,omitempty" tf:"-"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnsmxrecord_types.go
+++ b/apis/network/v1beta1/zz_dnsmxrecord_types.go
@@ -80,15 +80,15 @@ type DNSMXRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnsnsrecord_types.go
+++ b/apis/network/v1beta1/zz_dnsnsrecord_types.go
@@ -80,15 +80,15 @@ type DNSNSRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnsptrrecord_types.go
+++ b/apis/network/v1beta1/zz_dnsptrrecord_types.go
@@ -83,15 +83,15 @@ type DNSPTRRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnssrvrecord_types.go
+++ b/apis/network/v1beta1/zz_dnssrvrecord_types.go
@@ -80,15 +80,15 @@ type DNSSRVRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_dnstxtrecord_types.go
+++ b/apis/network/v1beta1/zz_dnstxtrecord_types.go
@@ -80,15 +80,15 @@ type DNSTXTRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=DNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.DNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a DNSZone to populate zoneName.
+	// Reference to a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a DNSZone to populate zoneName.
+	// Selector for a DNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_expressroutecircuitauthorization_types.go
+++ b/apis/network/v1beta1/zz_expressroutecircuitauthorization_types.go
@@ -34,15 +34,15 @@ type ExpressRouteCircuitAuthorizationObservation struct {
 type ExpressRouteCircuitAuthorizationParameters struct {
 
 	// The name of the Express Route Circuit in which to create the Authorization. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuit
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuit
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitName *string `json:"expressRouteCircuitName,omitempty" tf:"express_route_circuit_name,omitempty"`
 
-	// Reference to a ExpressRouteCircuit to populate expressRouteCircuitName.
+	// Reference to a ExpressRouteCircuit in network to populate expressRouteCircuitName.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitNameRef *v1.Reference `json:"expressRouteCircuitNameRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuit to populate expressRouteCircuitName.
+	// Selector for a ExpressRouteCircuit in network to populate expressRouteCircuitName.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitNameSelector *v1.Selector `json:"expressRouteCircuitNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_expressroutecircuitconnection_types.go
+++ b/apis/network/v1beta1/zz_expressroutecircuitconnection_types.go
@@ -22,15 +22,15 @@ type ExpressRouteCircuitConnectionInitParameters struct {
 	AddressPrefixIPv6 *string `json:"addressPrefixIpv6,omitempty" tf:"address_prefix_ipv6,omitempty"`
 
 	// The ID of the peered Express Route Circuit Private Peering. Changing this forces a new Express Route Circuit Connection to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuitPeering
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuitPeering
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PeerPeeringID *string `json:"peerPeeringId,omitempty" tf:"peer_peering_id,omitempty"`
 
-	// Reference to a ExpressRouteCircuitPeering to populate peerPeeringId.
+	// Reference to a ExpressRouteCircuitPeering in network to populate peerPeeringId.
 	// +kubebuilder:validation:Optional
 	PeerPeeringIDRef *v1.Reference `json:"peerPeeringIdRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuitPeering to populate peerPeeringId.
+	// Selector for a ExpressRouteCircuitPeering in network to populate peerPeeringId.
 	// +kubebuilder:validation:Optional
 	PeerPeeringIDSelector *v1.Selector `json:"peerPeeringIdSelector,omitempty" tf:"-"`
 }
@@ -68,30 +68,30 @@ type ExpressRouteCircuitConnectionParameters struct {
 	AuthorizationKeySecretRef *v1.SecretKeySelector `json:"authorizationKeySecretRef,omitempty" tf:"-"`
 
 	// The ID of the peered Express Route Circuit Private Peering. Changing this forces a new Express Route Circuit Connection to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuitPeering
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuitPeering
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PeerPeeringID *string `json:"peerPeeringId,omitempty" tf:"peer_peering_id,omitempty"`
 
-	// Reference to a ExpressRouteCircuitPeering to populate peerPeeringId.
+	// Reference to a ExpressRouteCircuitPeering in network to populate peerPeeringId.
 	// +kubebuilder:validation:Optional
 	PeerPeeringIDRef *v1.Reference `json:"peerPeeringIdRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuitPeering to populate peerPeeringId.
+	// Selector for a ExpressRouteCircuitPeering in network to populate peerPeeringId.
 	// +kubebuilder:validation:Optional
 	PeerPeeringIDSelector *v1.Selector `json:"peerPeeringIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Express Route Circuit Private Peering that this Express Route Circuit Connection connects with. Changing this forces a new Express Route Circuit Connection to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuitPeering
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuitPeering
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PeeringID *string `json:"peeringId,omitempty" tf:"peering_id,omitempty"`
 
-	// Reference to a ExpressRouteCircuitPeering to populate peeringId.
+	// Reference to a ExpressRouteCircuitPeering in network to populate peeringId.
 	// +kubebuilder:validation:Optional
 	PeeringIDRef *v1.Reference `json:"peeringIdRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuitPeering to populate peeringId.
+	// Selector for a ExpressRouteCircuitPeering in network to populate peeringId.
 	// +kubebuilder:validation:Optional
 	PeeringIDSelector *v1.Selector `json:"peeringIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_expressroutecircuitpeering_types.go
+++ b/apis/network/v1beta1/zz_expressroutecircuitpeering_types.go
@@ -90,15 +90,15 @@ type ExpressRouteCircuitPeeringObservation struct {
 type ExpressRouteCircuitPeeringParameters struct {
 
 	// The name of the ExpressRoute Circuit in which to create the Peering. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuit
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuit
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitName *string `json:"expressRouteCircuitName,omitempty" tf:"express_route_circuit_name,omitempty"`
 
-	// Reference to a ExpressRouteCircuit to populate expressRouteCircuitName.
+	// Reference to a ExpressRouteCircuit in network to populate expressRouteCircuitName.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitNameRef *v1.Reference `json:"expressRouteCircuitNameRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuit to populate expressRouteCircuitName.
+	// Selector for a ExpressRouteCircuit in network to populate expressRouteCircuitName.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitNameSelector *v1.Selector `json:"expressRouteCircuitNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_expressrouteconnection_types.go
+++ b/apis/network/v1beta1/zz_expressrouteconnection_types.go
@@ -22,15 +22,15 @@ type ExpressRouteConnectionInitParameters struct {
 	EnableInternetSecurity *bool `json:"enableInternetSecurity,omitempty" tf:"enable_internet_security,omitempty"`
 
 	// The ID of the Express Route Circuit Peering that this Express Route Connection connects with. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuitPeering
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuitPeering
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ExpressRouteCircuitPeeringID *string `json:"expressRouteCircuitPeeringId,omitempty" tf:"express_route_circuit_peering_id,omitempty"`
 
-	// Reference to a ExpressRouteCircuitPeering to populate expressRouteCircuitPeeringId.
+	// Reference to a ExpressRouteCircuitPeering in network to populate expressRouteCircuitPeeringId.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitPeeringIDRef *v1.Reference `json:"expressRouteCircuitPeeringIdRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuitPeering to populate expressRouteCircuitPeeringId.
+	// Selector for a ExpressRouteCircuitPeering in network to populate expressRouteCircuitPeeringId.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitPeeringIDSelector *v1.Selector `json:"expressRouteCircuitPeeringIdSelector,omitempty" tf:"-"`
 
@@ -82,16 +82,16 @@ type ExpressRouteConnectionParameters struct {
 	EnableInternetSecurity *bool `json:"enableInternetSecurity,omitempty" tf:"enable_internet_security,omitempty"`
 
 	// The ID of the Express Route Circuit Peering that this Express Route Connection connects with. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ExpressRouteCircuitPeering
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteCircuitPeering
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitPeeringID *string `json:"expressRouteCircuitPeeringId,omitempty" tf:"express_route_circuit_peering_id,omitempty"`
 
-	// Reference to a ExpressRouteCircuitPeering to populate expressRouteCircuitPeeringId.
+	// Reference to a ExpressRouteCircuitPeering in network to populate expressRouteCircuitPeeringId.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitPeeringIDRef *v1.Reference `json:"expressRouteCircuitPeeringIdRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteCircuitPeering to populate expressRouteCircuitPeeringId.
+	// Selector for a ExpressRouteCircuitPeering in network to populate expressRouteCircuitPeeringId.
 	// +kubebuilder:validation:Optional
 	ExpressRouteCircuitPeeringIDSelector *v1.Selector `json:"expressRouteCircuitPeeringIdSelector,omitempty" tf:"-"`
 
@@ -100,16 +100,16 @@ type ExpressRouteConnectionParameters struct {
 	ExpressRouteGatewayBypassEnabled *bool `json:"expressRouteGatewayBypassEnabled,omitempty" tf:"express_route_gateway_bypass_enabled,omitempty"`
 
 	// The ID of the Express Route Gateway that this Express Route Connection connects with. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ExpressRouteGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ExpressRouteGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ExpressRouteGatewayID *string `json:"expressRouteGatewayId,omitempty" tf:"express_route_gateway_id,omitempty"`
 
-	// Reference to a ExpressRouteGateway to populate expressRouteGatewayId.
+	// Reference to a ExpressRouteGateway in network to populate expressRouteGatewayId.
 	// +kubebuilder:validation:Optional
 	ExpressRouteGatewayIDRef *v1.Reference `json:"expressRouteGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a ExpressRouteGateway to populate expressRouteGatewayId.
+	// Selector for a ExpressRouteGateway in network to populate expressRouteGatewayId.
 	// +kubebuilder:validation:Optional
 	ExpressRouteGatewayIDSelector *v1.Selector `json:"expressRouteGatewayIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_expressroutegateway_types.go
+++ b/apis/network/v1beta1/zz_expressroutegateway_types.go
@@ -29,15 +29,15 @@ type ExpressRouteGatewayInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of a Virtual HUB within which the ExpressRoute gateway should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualHub
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VirtualHubID *string `json:"virtualHubId,omitempty" tf:"virtual_hub_id,omitempty"`
 
-	// Reference to a VirtualHub to populate virtualHubId.
+	// Reference to a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDRef *v1.Reference `json:"virtualHubIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualHub to populate virtualHubId.
+	// Selector for a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDSelector *v1.Selector `json:"virtualHubIdSelector,omitempty" tf:"-"`
 }
@@ -100,16 +100,16 @@ type ExpressRouteGatewayParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of a Virtual HUB within which the ExpressRoute gateway should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualHub
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VirtualHubID *string `json:"virtualHubId,omitempty" tf:"virtual_hub_id,omitempty"`
 
-	// Reference to a VirtualHub to populate virtualHubId.
+	// Reference to a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDRef *v1.Reference `json:"virtualHubIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualHub to populate virtualHubId.
+	// Selector for a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDSelector *v1.Selector `json:"virtualHubIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_firewall_types.go
+++ b/apis/network/v1beta1/zz_firewall_types.go
@@ -19,28 +19,28 @@ type FirewallIPConfigurationInitParameters struct {
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// The ID of the Public IP Address associated with the firewall.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// Reference to the subnet associated with the IP Configuration. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -67,30 +67,30 @@ type FirewallIPConfigurationParameters struct {
 	Name *string `json:"name" tf:"name,omitempty"`
 
 	// The ID of the Public IP Address associated with the firewall.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// Reference to the subnet associated with the IP Configuration. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -271,15 +271,15 @@ type ManagementIPConfigurationInitParameters struct {
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
 	// Reference to the subnet associated with the IP Configuration. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -310,16 +310,16 @@ type ManagementIPConfigurationParameters struct {
 	PublicIPAddressID *string `json:"publicIpAddressId" tf:"public_ip_address_id,omitempty"`
 
 	// Reference to the subnet associated with the IP Configuration. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_firewallapplicationrulecollection_types.go
+++ b/apis/network/v1beta1/zz_firewallapplicationrulecollection_types.go
@@ -52,15 +52,15 @@ type FirewallApplicationRuleCollectionParameters struct {
 	Action *string `json:"action,omitempty" tf:"action,omitempty"`
 
 	// Specifies the name of the Firewall in which the Application Rule Collection should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Firewall
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Firewall
 	// +kubebuilder:validation:Optional
 	AzureFirewallName *string `json:"azureFirewallName,omitempty" tf:"azure_firewall_name,omitempty"`
 
-	// Reference to a Firewall to populate azureFirewallName.
+	// Reference to a Firewall in network to populate azureFirewallName.
 	// +kubebuilder:validation:Optional
 	AzureFirewallNameRef *v1.Reference `json:"azureFirewallNameRef,omitempty" tf:"-"`
 
-	// Selector for a Firewall to populate azureFirewallName.
+	// Selector for a Firewall in network to populate azureFirewallName.
 	// +kubebuilder:validation:Optional
 	AzureFirewallNameSelector *v1.Selector `json:"azureFirewallNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_firewallnatrulecollection_types.go
+++ b/apis/network/v1beta1/zz_firewallnatrulecollection_types.go
@@ -52,15 +52,15 @@ type FirewallNATRuleCollectionParameters struct {
 	Action *string `json:"action,omitempty" tf:"action,omitempty"`
 
 	// Specifies the name of the Firewall in which the NAT Rule Collection should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Firewall
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Firewall
 	// +kubebuilder:validation:Optional
 	AzureFirewallName *string `json:"azureFirewallName,omitempty" tf:"azure_firewall_name,omitempty"`
 
-	// Reference to a Firewall to populate azureFirewallName.
+	// Reference to a Firewall in network to populate azureFirewallName.
 	// +kubebuilder:validation:Optional
 	AzureFirewallNameRef *v1.Reference `json:"azureFirewallNameRef,omitempty" tf:"-"`
 
-	// Selector for a Firewall to populate azureFirewallName.
+	// Selector for a Firewall in network to populate azureFirewallName.
 	// +kubebuilder:validation:Optional
 	AzureFirewallNameSelector *v1.Selector `json:"azureFirewallNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_firewallnetworkrulecollection_types.go
+++ b/apis/network/v1beta1/zz_firewallnetworkrulecollection_types.go
@@ -52,15 +52,15 @@ type FirewallNetworkRuleCollectionParameters struct {
 	Action *string `json:"action,omitempty" tf:"action,omitempty"`
 
 	// Specifies the name of the Firewall in which the Network Rule Collection should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Firewall
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Firewall
 	// +kubebuilder:validation:Optional
 	AzureFirewallName *string `json:"azureFirewallName,omitempty" tf:"azure_firewall_name,omitempty"`
 
-	// Reference to a Firewall to populate azureFirewallName.
+	// Reference to a Firewall in network to populate azureFirewallName.
 	// +kubebuilder:validation:Optional
 	AzureFirewallNameRef *v1.Reference `json:"azureFirewallNameRef,omitempty" tf:"-"`
 
-	// Selector for a Firewall to populate azureFirewallName.
+	// Selector for a Firewall in network to populate azureFirewallName.
 	// +kubebuilder:validation:Optional
 	AzureFirewallNameSelector *v1.Selector `json:"azureFirewallNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_firewallpolicyrulecollectiongroup_types.go
+++ b/apis/network/v1beta1/zz_firewallpolicyrulecollectiongroup_types.go
@@ -234,16 +234,16 @@ type FirewallPolicyRuleCollectionGroupParameters struct {
 	ApplicationRuleCollection []ApplicationRuleCollectionParameters `json:"applicationRuleCollection,omitempty" tf:"application_rule_collection,omitempty"`
 
 	// The ID of the Firewall Policy where the Firewall Policy Rule Collection Group should exist. Changing this forces a new Firewall Policy Rule Collection Group to be created.
-	// +crossplane:generate:reference:type=FirewallPolicy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.FirewallPolicy
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	FirewallPolicyID *string `json:"firewallPolicyId,omitempty" tf:"firewall_policy_id,omitempty"`
 
-	// Reference to a FirewallPolicy to populate firewallPolicyId.
+	// Reference to a FirewallPolicy in network to populate firewallPolicyId.
 	// +kubebuilder:validation:Optional
 	FirewallPolicyIDRef *v1.Reference `json:"firewallPolicyIdRef,omitempty" tf:"-"`
 
-	// Selector for a FirewallPolicy to populate firewallPolicyId.
+	// Selector for a FirewallPolicy in network to populate firewallPolicyId.
 	// +kubebuilder:validation:Optional
 	FirewallPolicyIDSelector *v1.Selector `json:"firewallPolicyIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_frontdoorrulesengine_types.go
+++ b/apis/network/v1beta1/zz_frontdoorrulesengine_types.go
@@ -77,15 +77,15 @@ type FrontdoorRulesEngineParameters struct {
 	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
 	// The name of the Front Door instance. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=FrontDoor
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.FrontDoor
 	// +kubebuilder:validation:Optional
 	FrontdoorName *string `json:"frontdoorName,omitempty" tf:"frontdoor_name,omitempty"`
 
-	// Reference to a FrontDoor to populate frontdoorName.
+	// Reference to a FrontDoor in network to populate frontdoorName.
 	// +kubebuilder:validation:Optional
 	FrontdoorNameRef *v1.Reference `json:"frontdoorNameRef,omitempty" tf:"-"`
 
-	// Selector for a FrontDoor to populate frontdoorName.
+	// Selector for a FrontDoor in network to populate frontdoorName.
 	// +kubebuilder:validation:Optional
 	FrontdoorNameSelector *v1.Selector `json:"frontdoorNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalancer_types.go
+++ b/apis/network/v1beta1/zz_loadbalancer_types.go
@@ -31,15 +31,15 @@ type LoadBalancerFrontendIPConfigurationInitParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// The ID of a Public IP Address which should be associated with the Load Balancer.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
@@ -47,15 +47,15 @@ type LoadBalancerFrontendIPConfigurationInitParameters struct {
 	PublicIPPrefixID *string `json:"publicIpPrefixId,omitempty" tf:"public_ip_prefix_id,omitempty"`
 
 	// The ID of the Subnet which should be associated with the IP Configuration.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
@@ -133,16 +133,16 @@ type LoadBalancerFrontendIPConfigurationParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// The ID of a Public IP Address which should be associated with the Load Balancer.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
@@ -151,16 +151,16 @@ type LoadBalancerFrontendIPConfigurationParameters struct {
 	PublicIPPrefixID *string `json:"publicIpPrefixId,omitempty" tf:"public_ip_prefix_id,omitempty"`
 
 	// The ID of the Subnet which should be associated with the IP Configuration.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalancerbackendaddresspool_types.go
+++ b/apis/network/v1beta1/zz_loadbalancerbackendaddresspool_types.go
@@ -52,16 +52,16 @@ type LoadBalancerBackendAddressPoolObservation struct {
 type LoadBalancerBackendAddressPoolParameters struct {
 
 	// The ID of the Load Balancer in which to create the Backend Address Pool. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LoadbalancerID *string `json:"loadbalancerId,omitempty" tf:"loadbalancer_id,omitempty"`
 
-	// Reference to a LoadBalancer to populate loadbalancerId.
+	// Reference to a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDRef *v1.Reference `json:"loadbalancerIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancer to populate loadbalancerId.
+	// Selector for a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDSelector *v1.Selector `json:"loadbalancerIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalancerbackendaddresspooladdress_types.go
+++ b/apis/network/v1beta1/zz_loadbalancerbackendaddresspooladdress_types.go
@@ -42,15 +42,15 @@ type LoadBalancerBackendAddressPoolAddressInitParameters struct {
 
 	// The ID of the Virtual Network within which the Backend Address Pool should exist.
 	// For regional load balancer, user needs to specify `virtual_network_id` and `ip_address`
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VirtualNetworkID *string `json:"virtualNetworkId,omitempty" tf:"virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate virtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDRef *v1.Reference `json:"virtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate virtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDSelector *v1.Selector `json:"virtualNetworkIdSelector,omitempty" tf:"-"`
 }
@@ -86,16 +86,16 @@ type LoadBalancerBackendAddressPoolAddressParameters struct {
 	BackendAddressIPConfigurationID *string `json:"backendAddressIpConfigurationId,omitempty" tf:"backend_address_ip_configuration_id,omitempty"`
 
 	// The ID of the Backend Address Pool. Changing this forces a new Backend Address Pool Address to be created.
-	// +crossplane:generate:reference:type=LoadBalancerBackendAddressPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerBackendAddressPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolID *string `json:"backendAddressPoolId,omitempty" tf:"backend_address_pool_id,omitempty"`
 
-	// Reference to a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Reference to a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDRef *v1.Reference `json:"backendAddressPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Selector for a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDSelector *v1.Selector `json:"backendAddressPoolIdSelector,omitempty" tf:"-"`
 
@@ -105,16 +105,16 @@ type LoadBalancerBackendAddressPoolAddressParameters struct {
 
 	// The ID of the Virtual Network within which the Backend Address Pool should exist.
 	// For regional load balancer, user needs to specify `virtual_network_id` and `ip_address`
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VirtualNetworkID *string `json:"virtualNetworkId,omitempty" tf:"virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate virtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDRef *v1.Reference `json:"virtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate virtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDSelector *v1.Selector `json:"virtualNetworkIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_loadbalancernatpool_types.go
+++ b/apis/network/v1beta1/zz_loadbalancernatpool_types.go
@@ -118,16 +118,16 @@ type LoadBalancerNatPoolParameters struct {
 	IdleTimeoutInMinutes *float64 `json:"idleTimeoutInMinutes,omitempty" tf:"idle_timeout_in_minutes,omitempty"`
 
 	// The ID of the Load Balancer in which to create the NAT pool. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LoadbalancerID *string `json:"loadbalancerId,omitempty" tf:"loadbalancer_id,omitempty"`
 
-	// Reference to a LoadBalancer to populate loadbalancerId.
+	// Reference to a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDRef *v1.Reference `json:"loadbalancerIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancer to populate loadbalancerId.
+	// Selector for a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDSelector *v1.Selector `json:"loadbalancerIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalancernatrule_types.go
+++ b/apis/network/v1beta1/zz_loadbalancernatrule_types.go
@@ -165,16 +165,16 @@ type LoadBalancerNatRuleParameters struct {
 	IdleTimeoutInMinutes *float64 `json:"idleTimeoutInMinutes,omitempty" tf:"idle_timeout_in_minutes,omitempty"`
 
 	// The ID of the Load Balancer in which to create the NAT Rule. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LoadbalancerID *string `json:"loadbalancerId,omitempty" tf:"loadbalancer_id,omitempty"`
 
-	// Reference to a LoadBalancer to populate loadbalancerId.
+	// Reference to a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDRef *v1.Reference `json:"loadbalancerIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancer to populate loadbalancerId.
+	// Selector for a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDSelector *v1.Selector `json:"loadbalancerIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalanceroutboundrule_types.go
+++ b/apis/network/v1beta1/zz_loadbalanceroutboundrule_types.go
@@ -41,15 +41,15 @@ type LoadBalancerOutboundRuleInitParameters struct {
 	AllocatedOutboundPorts *float64 `json:"allocatedOutboundPorts,omitempty" tf:"allocated_outbound_ports,omitempty"`
 
 	// The ID of the Backend Address Pool. Outbound traffic is randomly load balanced across IPs in the backend IPs.
-	// +crossplane:generate:reference:type=LoadBalancerBackendAddressPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerBackendAddressPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	BackendAddressPoolID *string `json:"backendAddressPoolId,omitempty" tf:"backend_address_pool_id,omitempty"`
 
-	// Reference to a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Reference to a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDRef *v1.Reference `json:"backendAddressPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Selector for a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDSelector *v1.Selector `json:"backendAddressPoolIdSelector,omitempty" tf:"-"`
 
@@ -100,16 +100,16 @@ type LoadBalancerOutboundRuleParameters struct {
 	AllocatedOutboundPorts *float64 `json:"allocatedOutboundPorts,omitempty" tf:"allocated_outbound_ports,omitempty"`
 
 	// The ID of the Backend Address Pool. Outbound traffic is randomly load balanced across IPs in the backend IPs.
-	// +crossplane:generate:reference:type=LoadBalancerBackendAddressPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerBackendAddressPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolID *string `json:"backendAddressPoolId,omitempty" tf:"backend_address_pool_id,omitempty"`
 
-	// Reference to a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Reference to a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDRef *v1.Reference `json:"backendAddressPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Selector for a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDSelector *v1.Selector `json:"backendAddressPoolIdSelector,omitempty" tf:"-"`
 
@@ -126,16 +126,16 @@ type LoadBalancerOutboundRuleParameters struct {
 	IdleTimeoutInMinutes *float64 `json:"idleTimeoutInMinutes,omitempty" tf:"idle_timeout_in_minutes,omitempty"`
 
 	// The ID of the Load Balancer in which to create the Outbound Rule. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LoadbalancerID *string `json:"loadbalancerId,omitempty" tf:"loadbalancer_id,omitempty"`
 
-	// Reference to a LoadBalancer to populate loadbalancerId.
+	// Reference to a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDRef *v1.Reference `json:"loadbalancerIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancer to populate loadbalancerId.
+	// Selector for a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDSelector *v1.Selector `json:"loadbalancerIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalancerprobe_types.go
+++ b/apis/network/v1beta1/zz_loadbalancerprobe_types.go
@@ -71,16 +71,16 @@ type LoadBalancerProbeParameters struct {
 	IntervalInSeconds *float64 `json:"intervalInSeconds,omitempty" tf:"interval_in_seconds,omitempty"`
 
 	// The ID of the LoadBalancer in which to create the Probe. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LoadbalancerID *string `json:"loadbalancerId,omitempty" tf:"loadbalancer_id,omitempty"`
 
-	// Reference to a LoadBalancer to populate loadbalancerId.
+	// Reference to a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDRef *v1.Reference `json:"loadbalancerIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancer to populate loadbalancerId.
+	// Selector for a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDSelector *v1.Selector `json:"loadbalancerIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_loadbalancerrule_types.go
+++ b/apis/network/v1beta1/zz_loadbalancerrule_types.go
@@ -133,16 +133,16 @@ type LoadBalancerRuleParameters struct {
 	LoadDistribution *string `json:"loadDistribution,omitempty" tf:"load_distribution,omitempty"`
 
 	// The ID of the Load Balancer in which to create the Rule. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	LoadbalancerID *string `json:"loadbalancerId,omitempty" tf:"loadbalancer_id,omitempty"`
 
-	// Reference to a LoadBalancer to populate loadbalancerId.
+	// Reference to a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDRef *v1.Reference `json:"loadbalancerIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancer to populate loadbalancerId.
+	// Selector for a LoadBalancer in network to populate loadbalancerId.
 	// +kubebuilder:validation:Optional
 	LoadbalancerIDSelector *v1.Selector `json:"loadbalancerIdSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_managerstaticmember_types.go
+++ b/apis/network/v1beta1/zz_managerstaticmember_types.go
@@ -16,15 +16,15 @@ import (
 type ManagerStaticMemberInitParameters struct {
 
 	// Specifies the Resource ID of the Virtual Network using as the Static Member. Changing this forces a new Network Manager Static Member to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	TargetVirtualNetworkID *string `json:"targetVirtualNetworkId,omitempty" tf:"target_virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate targetVirtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate targetVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	TargetVirtualNetworkIDRef *v1.Reference `json:"targetVirtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate targetVirtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate targetVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	TargetVirtualNetworkIDSelector *v1.Selector `json:"targetVirtualNetworkIdSelector,omitempty" tf:"-"`
 }
@@ -61,16 +61,16 @@ type ManagerStaticMemberParameters struct {
 	NetworkGroupIDSelector *v1.Selector `json:"networkGroupIdSelector,omitempty" tf:"-"`
 
 	// Specifies the Resource ID of the Virtual Network using as the Static Member. Changing this forces a new Network Manager Static Member to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	TargetVirtualNetworkID *string `json:"targetVirtualNetworkId,omitempty" tf:"target_virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate targetVirtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate targetVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	TargetVirtualNetworkIDRef *v1.Reference `json:"targetVirtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate targetVirtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate targetVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	TargetVirtualNetworkIDSelector *v1.Selector `json:"targetVirtualNetworkIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_natgatewaypublicipassociation_types.go
+++ b/apis/network/v1beta1/zz_natgatewaypublicipassociation_types.go
@@ -16,28 +16,28 @@ import (
 type NATGatewayPublicIPAssociationInitParameters struct {
 
 	// The ID of the NAT Gateway. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NATGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NATGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NATGatewayID *string `json:"natGatewayId,omitempty" tf:"nat_gateway_id,omitempty"`
 
-	// Reference to a NATGateway to populate natGatewayId.
+	// Reference to a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDRef *v1.Reference `json:"natGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a NATGateway to populate natGatewayId.
+	// Selector for a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDSelector *v1.Selector `json:"natGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Public IP which this NAT Gateway which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 }
@@ -55,30 +55,30 @@ type NATGatewayPublicIPAssociationObservation struct {
 type NATGatewayPublicIPAssociationParameters struct {
 
 	// The ID of the NAT Gateway. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NATGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NATGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NATGatewayID *string `json:"natGatewayId,omitempty" tf:"nat_gateway_id,omitempty"`
 
-	// Reference to a NATGateway to populate natGatewayId.
+	// Reference to a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDRef *v1.Reference `json:"natGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a NATGateway to populate natGatewayId.
+	// Selector for a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDSelector *v1.Selector `json:"natGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Public IP which this NAT Gateway which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PublicIP
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIP
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPAddressID *string `json:"publicIpAddressId,omitempty" tf:"public_ip_address_id,omitempty"`
 
-	// Reference to a PublicIP to populate publicIpAddressId.
+	// Reference to a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDRef *v1.Reference `json:"publicIpAddressIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIP to populate publicIpAddressId.
+	// Selector for a PublicIP in network to populate publicIpAddressId.
 	// +kubebuilder:validation:Optional
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_natgatewaypublicipprefixassociation_types.go
+++ b/apis/network/v1beta1/zz_natgatewaypublicipprefixassociation_types.go
@@ -16,28 +16,28 @@ import (
 type NATGatewayPublicIPPrefixAssociationInitParameters struct {
 
 	// The ID of the NAT Gateway. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NATGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NATGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NATGatewayID *string `json:"natGatewayId,omitempty" tf:"nat_gateway_id,omitempty"`
 
-	// Reference to a NATGateway to populate natGatewayId.
+	// Reference to a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDRef *v1.Reference `json:"natGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a NATGateway to populate natGatewayId.
+	// Selector for a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDSelector *v1.Selector `json:"natGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Public IP Prefix which this NAT Gateway which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PublicIPPrefix
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIPPrefix
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PublicIPPrefixID *string `json:"publicIpPrefixId,omitempty" tf:"public_ip_prefix_id,omitempty"`
 
-	// Reference to a PublicIPPrefix to populate publicIpPrefixId.
+	// Reference to a PublicIPPrefix in network to populate publicIpPrefixId.
 	// +kubebuilder:validation:Optional
 	PublicIPPrefixIDRef *v1.Reference `json:"publicIpPrefixIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIPPrefix to populate publicIpPrefixId.
+	// Selector for a PublicIPPrefix in network to populate publicIpPrefixId.
 	// +kubebuilder:validation:Optional
 	PublicIPPrefixIDSelector *v1.Selector `json:"publicIpPrefixIdSelector,omitempty" tf:"-"`
 }
@@ -55,30 +55,30 @@ type NATGatewayPublicIPPrefixAssociationObservation struct {
 type NATGatewayPublicIPPrefixAssociationParameters struct {
 
 	// The ID of the NAT Gateway. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NATGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NATGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NATGatewayID *string `json:"natGatewayId,omitempty" tf:"nat_gateway_id,omitempty"`
 
-	// Reference to a NATGateway to populate natGatewayId.
+	// Reference to a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDRef *v1.Reference `json:"natGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a NATGateway to populate natGatewayId.
+	// Selector for a NATGateway in network to populate natGatewayId.
 	// +kubebuilder:validation:Optional
 	NATGatewayIDSelector *v1.Selector `json:"natGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Public IP Prefix which this NAT Gateway which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PublicIPPrefix
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PublicIPPrefix
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PublicIPPrefixID *string `json:"publicIpPrefixId,omitempty" tf:"public_ip_prefix_id,omitempty"`
 
-	// Reference to a PublicIPPrefix to populate publicIpPrefixId.
+	// Reference to a PublicIPPrefix in network to populate publicIpPrefixId.
 	// +kubebuilder:validation:Optional
 	PublicIPPrefixIDRef *v1.Reference `json:"publicIpPrefixIdRef,omitempty" tf:"-"`
 
-	// Selector for a PublicIPPrefix to populate publicIpPrefixId.
+	// Selector for a PublicIPPrefix in network to populate publicIpPrefixId.
 	// +kubebuilder:validation:Optional
 	PublicIPPrefixIDSelector *v1.Selector `json:"publicIpPrefixIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_networkinterfaceapplicationsecuritygroupassociation_types.go
+++ b/apis/network/v1beta1/zz_networkinterfaceapplicationsecuritygroupassociation_types.go
@@ -16,28 +16,28 @@ import (
 type NetworkInterfaceApplicationSecurityGroupAssociationInitParameters struct {
 
 	// The ID of the Application Security Group which this Network Interface which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ApplicationSecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ApplicationSecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ApplicationSecurityGroupID *string `json:"applicationSecurityGroupId,omitempty" tf:"application_security_group_id,omitempty"`
 
-	// Reference to a ApplicationSecurityGroup to populate applicationSecurityGroupId.
+	// Reference to a ApplicationSecurityGroup in network to populate applicationSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	ApplicationSecurityGroupIDRef *v1.Reference `json:"applicationSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a ApplicationSecurityGroup to populate applicationSecurityGroupId.
+	// Selector for a ApplicationSecurityGroup in network to populate applicationSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	ApplicationSecurityGroupIDSelector *v1.Selector `json:"applicationSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -56,30 +56,30 @@ type NetworkInterfaceApplicationSecurityGroupAssociationObservation struct {
 type NetworkInterfaceApplicationSecurityGroupAssociationParameters struct {
 
 	// The ID of the Application Security Group which this Network Interface which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=ApplicationSecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.ApplicationSecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ApplicationSecurityGroupID *string `json:"applicationSecurityGroupId,omitempty" tf:"application_security_group_id,omitempty"`
 
-	// Reference to a ApplicationSecurityGroup to populate applicationSecurityGroupId.
+	// Reference to a ApplicationSecurityGroup in network to populate applicationSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	ApplicationSecurityGroupIDRef *v1.Reference `json:"applicationSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a ApplicationSecurityGroup to populate applicationSecurityGroupId.
+	// Selector for a ApplicationSecurityGroup in network to populate applicationSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	ApplicationSecurityGroupIDSelector *v1.Selector `json:"applicationSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_networkinterfacebackendaddresspoolassociation_types.go
+++ b/apis/network/v1beta1/zz_networkinterfacebackendaddresspoolassociation_types.go
@@ -16,15 +16,15 @@ import (
 type NetworkInterfaceBackendAddressPoolAssociationInitParameters struct {
 
 	// The ID of the Load Balancer Backend Address Pool which this Network Interface should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancerBackendAddressPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerBackendAddressPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	BackendAddressPoolID *string `json:"backendAddressPoolId,omitempty" tf:"backend_address_pool_id,omitempty"`
 
-	// Reference to a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Reference to a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDRef *v1.Reference `json:"backendAddressPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Selector for a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDSelector *v1.Selector `json:"backendAddressPoolIdSelector,omitempty" tf:"-"`
 
@@ -32,15 +32,15 @@ type NetworkInterfaceBackendAddressPoolAssociationInitParameters struct {
 	IPConfigurationName *string `json:"ipConfigurationName,omitempty" tf:"ip_configuration_name,omitempty"`
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -62,16 +62,16 @@ type NetworkInterfaceBackendAddressPoolAssociationObservation struct {
 type NetworkInterfaceBackendAddressPoolAssociationParameters struct {
 
 	// The ID of the Load Balancer Backend Address Pool which this Network Interface should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancerBackendAddressPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerBackendAddressPool
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolID *string `json:"backendAddressPoolId,omitempty" tf:"backend_address_pool_id,omitempty"`
 
-	// Reference to a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Reference to a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDRef *v1.Reference `json:"backendAddressPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerBackendAddressPool to populate backendAddressPoolId.
+	// Selector for a LoadBalancerBackendAddressPool in network to populate backendAddressPoolId.
 	// +kubebuilder:validation:Optional
 	BackendAddressPoolIDSelector *v1.Selector `json:"backendAddressPoolIdSelector,omitempty" tf:"-"`
 
@@ -80,16 +80,16 @@ type NetworkInterfaceBackendAddressPoolAssociationParameters struct {
 	IPConfigurationName *string `json:"ipConfigurationName,omitempty" tf:"ip_configuration_name,omitempty"`
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_networkinterfacenatruleassociation_types.go
+++ b/apis/network/v1beta1/zz_networkinterfacenatruleassociation_types.go
@@ -19,28 +19,28 @@ type NetworkInterfaceNatRuleAssociationInitParameters struct {
 	IPConfigurationName *string `json:"ipConfigurationName,omitempty" tf:"ip_configuration_name,omitempty"`
 
 	// The ID of the Load Balancer NAT Rule which this Network Interface which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancerNatRule
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerNatRule
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NATRuleID *string `json:"natRuleId,omitempty" tf:"nat_rule_id,omitempty"`
 
-	// Reference to a LoadBalancerNatRule to populate natRuleId.
+	// Reference to a LoadBalancerNatRule in network to populate natRuleId.
 	// +kubebuilder:validation:Optional
 	NATRuleIDRef *v1.Reference `json:"natRuleIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerNatRule to populate natRuleId.
+	// Selector for a LoadBalancerNatRule in network to populate natRuleId.
 	// +kubebuilder:validation:Optional
 	NATRuleIDSelector *v1.Selector `json:"natRuleIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -65,30 +65,30 @@ type NetworkInterfaceNatRuleAssociationParameters struct {
 	IPConfigurationName *string `json:"ipConfigurationName,omitempty" tf:"ip_configuration_name,omitempty"`
 
 	// The ID of the Load Balancer NAT Rule which this Network Interface which should be connected to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=LoadBalancerNatRule
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.LoadBalancerNatRule
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NATRuleID *string `json:"natRuleId,omitempty" tf:"nat_rule_id,omitempty"`
 
-	// Reference to a LoadBalancerNatRule to populate natRuleId.
+	// Reference to a LoadBalancerNatRule in network to populate natRuleId.
 	// +kubebuilder:validation:Optional
 	NATRuleIDRef *v1.Reference `json:"natRuleIdRef,omitempty" tf:"-"`
 
-	// Selector for a LoadBalancerNatRule to populate natRuleId.
+	// Selector for a LoadBalancerNatRule in network to populate natRuleId.
 	// +kubebuilder:validation:Optional
 	NATRuleIDSelector *v1.Selector `json:"natRuleIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_networkinterfacesecuritygroupassociation_types.go
+++ b/apis/network/v1beta1/zz_networkinterfacesecuritygroupassociation_types.go
@@ -16,28 +16,28 @@ import (
 type NetworkInterfaceSecurityGroupAssociationInitParameters struct {
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Network Security Group which should be attached to the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty" tf:"network_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupId.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDRef *v1.Reference `json:"networkSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupId.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDSelector *v1.Selector `json:"networkSecurityGroupIdSelector,omitempty" tf:"-"`
 }
@@ -55,30 +55,30 @@ type NetworkInterfaceSecurityGroupAssociationObservation struct {
 type NetworkInterfaceSecurityGroupAssociationParameters struct {
 
 	// The ID of the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.NetworkInterface
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in network to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Network Security Group which should be attached to the Network Interface. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty" tf:"network_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupId.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDRef *v1.Reference `json:"networkSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupId.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDSelector *v1.Selector `json:"networkSecurityGroupIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_packetcapture_types.go
+++ b/apis/network/v1beta1/zz_packetcapture_types.go
@@ -142,15 +142,15 @@ type PacketCaptureParameters struct {
 	MaximumCaptureDuration *float64 `json:"maximumCaptureDuration,omitempty" tf:"maximum_capture_duration,omitempty"`
 
 	// The name of the Network Watcher. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Watcher
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Watcher
 	// +kubebuilder:validation:Optional
 	NetworkWatcherName *string `json:"networkWatcherName,omitempty" tf:"network_watcher_name,omitempty"`
 
-	// Reference to a Watcher to populate networkWatcherName.
+	// Reference to a Watcher in network to populate networkWatcherName.
 	// +kubebuilder:validation:Optional
 	NetworkWatcherNameRef *v1.Reference `json:"networkWatcherNameRef,omitempty" tf:"-"`
 
-	// Selector for a Watcher to populate networkWatcherName.
+	// Selector for a Watcher in network to populate networkWatcherName.
 	// +kubebuilder:validation:Optional
 	NetworkWatcherNameSelector *v1.Selector `json:"networkWatcherNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_pointtositevpngateway_types.go
+++ b/apis/network/v1beta1/zz_pointtositevpngateway_types.go
@@ -84,28 +84,28 @@ type PointToSiteVPNGatewayInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the VPN Server Configuration which this Point-to-Site VPN Gateway should use. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VPNServerConfiguration
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VPNServerConfiguration
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VPNServerConfigurationID *string `json:"vpnServerConfigurationId,omitempty" tf:"vpn_server_configuration_id,omitempty"`
 
-	// Reference to a VPNServerConfiguration to populate vpnServerConfigurationId.
+	// Reference to a VPNServerConfiguration in network to populate vpnServerConfigurationId.
 	// +kubebuilder:validation:Optional
 	VPNServerConfigurationIDRef *v1.Reference `json:"vpnServerConfigurationIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPNServerConfiguration to populate vpnServerConfigurationId.
+	// Selector for a VPNServerConfiguration in network to populate vpnServerConfigurationId.
 	// +kubebuilder:validation:Optional
 	VPNServerConfigurationIDSelector *v1.Selector `json:"vpnServerConfigurationIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Virtual Hub where this Point-to-Site VPN Gateway should exist. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualHub
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VirtualHubID *string `json:"virtualHubId,omitempty" tf:"virtual_hub_id,omitempty"`
 
-	// Reference to a VirtualHub to populate virtualHubId.
+	// Reference to a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDRef *v1.Reference `json:"virtualHubIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualHub to populate virtualHubId.
+	// Selector for a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDSelector *v1.Selector `json:"virtualHubIdSelector,omitempty" tf:"-"`
 }
@@ -185,30 +185,30 @@ type PointToSiteVPNGatewayParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the VPN Server Configuration which this Point-to-Site VPN Gateway should use. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VPNServerConfiguration
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VPNServerConfiguration
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VPNServerConfigurationID *string `json:"vpnServerConfigurationId,omitempty" tf:"vpn_server_configuration_id,omitempty"`
 
-	// Reference to a VPNServerConfiguration to populate vpnServerConfigurationId.
+	// Reference to a VPNServerConfiguration in network to populate vpnServerConfigurationId.
 	// +kubebuilder:validation:Optional
 	VPNServerConfigurationIDRef *v1.Reference `json:"vpnServerConfigurationIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPNServerConfiguration to populate vpnServerConfigurationId.
+	// Selector for a VPNServerConfiguration in network to populate vpnServerConfigurationId.
 	// +kubebuilder:validation:Optional
 	VPNServerConfigurationIDSelector *v1.Selector `json:"vpnServerConfigurationIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Virtual Hub where this Point-to-Site VPN Gateway should exist. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualHub
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualHub
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VirtualHubID *string `json:"virtualHubId,omitempty" tf:"virtual_hub_id,omitempty"`
 
-	// Reference to a VirtualHub to populate virtualHubId.
+	// Reference to a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDRef *v1.Reference `json:"virtualHubIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualHub to populate virtualHubId.
+	// Selector for a VirtualHub in network to populate virtualHubId.
 	// +kubebuilder:validation:Optional
 	VirtualHubIDSelector *v1.Selector `json:"virtualHubIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednsaaaarecord_types.go
+++ b/apis/network/v1beta1/zz_privatednsaaaarecord_types.go
@@ -83,15 +83,15 @@ type PrivateDNSAAAARecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednsarecord_types.go
+++ b/apis/network/v1beta1/zz_privatednsarecord_types.go
@@ -83,15 +83,15 @@ type PrivateDNSARecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednscnamerecord_types.go
+++ b/apis/network/v1beta1/zz_privatednscnamerecord_types.go
@@ -80,15 +80,15 @@ type PrivateDNSCNAMERecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednsmxrecord_types.go
+++ b/apis/network/v1beta1/zz_privatednsmxrecord_types.go
@@ -80,15 +80,15 @@ type PrivateDNSMXRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednsptrrecord_types.go
+++ b/apis/network/v1beta1/zz_privatednsptrrecord_types.go
@@ -83,15 +83,15 @@ type PrivateDNSPTRRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednssrvrecord_types.go
+++ b/apis/network/v1beta1/zz_privatednssrvrecord_types.go
@@ -80,15 +80,15 @@ type PrivateDNSSRVRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednstxtrecord_types.go
+++ b/apis/network/v1beta1/zz_privatednstxtrecord_types.go
@@ -80,15 +80,15 @@ type PrivateDNSTXTRecordParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	ZoneName *string `json:"zoneName,omitempty" tf:"zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate zoneName.
+	// Reference to a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameRef *v1.Reference `json:"zoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate zoneName.
+	// Selector for a PrivateDNSZone in network to populate zoneName.
 	// +kubebuilder:validation:Optional
 	ZoneNameSelector *v1.Selector `json:"zoneNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatednszonevirtualnetworklink_types.go
+++ b/apis/network/v1beta1/zz_privatednszonevirtualnetworklink_types.go
@@ -23,15 +23,15 @@ type PrivateDNSZoneVirtualNetworkLinkInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VirtualNetworkID *string `json:"virtualNetworkId,omitempty" tf:"virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate virtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDRef *v1.Reference `json:"virtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate virtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDSelector *v1.Selector `json:"virtualNetworkIdSelector,omitempty" tf:"-"`
 }
@@ -61,15 +61,15 @@ type PrivateDNSZoneVirtualNetworkLinkObservation struct {
 type PrivateDNSZoneVirtualNetworkLinkParameters struct {
 
 	// The name of the Private DNS zone (without a terminating dot). Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneName *string `json:"privateDnsZoneName,omitempty" tf:"private_dns_zone_name,omitempty"`
 
-	// Reference to a PrivateDNSZone to populate privateDnsZoneName.
+	// Reference to a PrivateDNSZone in network to populate privateDnsZoneName.
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneNameRef *v1.Reference `json:"privateDnsZoneNameRef,omitempty" tf:"-"`
 
-	// Selector for a PrivateDNSZone to populate privateDnsZoneName.
+	// Selector for a PrivateDNSZone in network to populate privateDnsZoneName.
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneNameSelector *v1.Selector `json:"privateDnsZoneNameSelector,omitempty" tf:"-"`
 
@@ -96,16 +96,16 @@ type PrivateDNSZoneVirtualNetworkLinkParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VirtualNetworkID *string `json:"virtualNetworkId,omitempty" tf:"virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate virtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDRef *v1.Reference `json:"virtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate virtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate virtualNetworkId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkIDSelector *v1.Selector `json:"virtualNetworkIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privateendpoint_types.go
+++ b/apis/network/v1beta1/zz_privateendpoint_types.go
@@ -55,15 +55,15 @@ type PrivateDNSZoneGroupInitParameters struct {
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Specifies the list of Private DNS Zones to include within the private_dns_zone_group.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PrivateDNSZoneIds []*string `json:"privateDnsZoneIds,omitempty" tf:"private_dns_zone_ids,omitempty"`
 
-	// References to PrivateDNSZone to populate privateDnsZoneIds.
+	// References to PrivateDNSZone in network to populate privateDnsZoneIds.
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneIdsRefs []v1.Reference `json:"privateDnsZoneIdsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of PrivateDNSZone to populate privateDnsZoneIds.
+	// Selector for a list of PrivateDNSZone in network to populate privateDnsZoneIds.
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneIdsSelector *v1.Selector `json:"privateDnsZoneIdsSelector,omitempty" tf:"-"`
 }
@@ -87,16 +87,16 @@ type PrivateDNSZoneGroupParameters struct {
 	Name *string `json:"name" tf:"name,omitempty"`
 
 	// Specifies the list of Private DNS Zones to include within the private_dns_zone_group.
-	// +crossplane:generate:reference:type=PrivateDNSZone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.PrivateDNSZone
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneIds []*string `json:"privateDnsZoneIds,omitempty" tf:"private_dns_zone_ids,omitempty"`
 
-	// References to PrivateDNSZone to populate privateDnsZoneIds.
+	// References to PrivateDNSZone in network to populate privateDnsZoneIds.
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneIdsRefs []v1.Reference `json:"privateDnsZoneIdsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of PrivateDNSZone to populate privateDnsZoneIds.
+	// Selector for a list of PrivateDNSZone in network to populate privateDnsZoneIds.
 	// +kubebuilder:validation:Optional
 	PrivateDNSZoneIdsSelector *v1.Selector `json:"privateDnsZoneIdsSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_privatelinkservice_types.go
+++ b/apis/network/v1beta1/zz_privatelinkservice_types.go
@@ -28,15 +28,15 @@ type NATIPConfigurationInitParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// Specifies the ID of the Subnet which should be used for the Private Link Service.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -78,16 +78,16 @@ type NATIPConfigurationParameters struct {
 	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty" tf:"private_ip_address_version,omitempty"`
 
 	// Specifies the ID of the Subnet which should be used for the Private Link Service.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_profile_types.go
+++ b/apis/network/v1beta1/zz_profile_types.go
@@ -19,15 +19,15 @@ type ContainerNetworkInterfaceIPConfigurationInitParameters struct {
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Reference to the subnet associated with the IP Configuration.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -48,16 +48,16 @@ type ContainerNetworkInterfaceIPConfigurationParameters struct {
 	Name *string `json:"name" tf:"name,omitempty"`
 
 	// Reference to the subnet associated with the IP Configuration.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_securityrule_types.go
+++ b/apis/network/v1beta1/zz_securityrule_types.go
@@ -168,15 +168,15 @@ type SecurityRuleParameters_2 struct {
 	Direction *string `json:"direction,omitempty" tf:"direction,omitempty"`
 
 	// The name of the Network Security Group that we want to attach the rule to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupName *string `json:"networkSecurityGroupName,omitempty" tf:"network_security_group_name,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupName.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupName.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupNameRef *v1.Reference `json:"networkSecurityGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupName.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupName.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupNameSelector *v1.Selector `json:"networkSecurityGroupNameSelector,omitempty" tf:"-"`
 

--- a/apis/network/v1beta1/zz_subnet_types.go
+++ b/apis/network/v1beta1/zz_subnet_types.go
@@ -182,15 +182,15 @@ type SubnetParameters struct {
 	ServiceEndpoints []*string `json:"serviceEndpoints,omitempty" tf:"service_endpoints,omitempty"`
 
 	// The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +kubebuilder:validation:Optional
 	VirtualNetworkName *string `json:"virtualNetworkName,omitempty" tf:"virtual_network_name,omitempty"`
 
-	// Reference to a VirtualNetwork to populate virtualNetworkName.
+	// Reference to a VirtualNetwork in network to populate virtualNetworkName.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkNameRef *v1.Reference `json:"virtualNetworkNameRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate virtualNetworkName.
+	// Selector for a VirtualNetwork in network to populate virtualNetworkName.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkNameSelector *v1.Selector `json:"virtualNetworkNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_subnetnatgatewayassociation_types.go
+++ b/apis/network/v1beta1/zz_subnetnatgatewayassociation_types.go
@@ -29,15 +29,15 @@ type SubnetNATGatewayAssociationInitParameters struct {
 	NATGatewayIDSelector *v1.Selector `json:"natGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -71,16 +71,16 @@ type SubnetNATGatewayAssociationParameters struct {
 	NATGatewayIDSelector *v1.Selector `json:"natGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_subnetnetworksecuritygroupassociation_types.go
+++ b/apis/network/v1beta1/zz_subnetnetworksecuritygroupassociation_types.go
@@ -16,28 +16,28 @@ import (
 type SubnetNetworkSecurityGroupAssociationInitParameters struct {
 
 	// The ID of the Network Security Group which should be associated with the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty" tf:"network_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupId.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDRef *v1.Reference `json:"networkSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupId.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDSelector *v1.Selector `json:"networkSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -57,30 +57,30 @@ type SubnetNetworkSecurityGroupAssociationObservation struct {
 type SubnetNetworkSecurityGroupAssociationParameters struct {
 
 	// The ID of the Network Security Group which should be associated with the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty" tf:"network_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupId.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDRef *v1.Reference `json:"networkSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupId.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDSelector *v1.Selector `json:"networkSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_subnetroutetableassociation_types.go
+++ b/apis/network/v1beta1/zz_subnetroutetableassociation_types.go
@@ -16,28 +16,28 @@ import (
 type SubnetRouteTableAssociationInitParameters struct {
 
 	// The ID of the Route Table which should be associated with the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=RouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.RouteTable
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	RouteTableID *string `json:"routeTableId,omitempty" tf:"route_table_id,omitempty"`
 
-	// Reference to a RouteTable to populate routeTableId.
+	// Reference to a RouteTable in network to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDRef *v1.Reference `json:"routeTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a RouteTable to populate routeTableId.
+	// Selector for a RouteTable in network to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDSelector *v1.Selector `json:"routeTableIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -57,30 +57,30 @@ type SubnetRouteTableAssociationObservation struct {
 type SubnetRouteTableAssociationParameters struct {
 
 	// The ID of the Route Table which should be associated with the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=RouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.RouteTable
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	RouteTableID *string `json:"routeTableId,omitempty" tf:"route_table_id,omitempty"`
 
-	// Reference to a RouteTable to populate routeTableId.
+	// Reference to a RouteTable in network to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDRef *v1.Reference `json:"routeTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a RouteTable to populate routeTableId.
+	// Selector for a RouteTable in network to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDSelector *v1.Selector `json:"routeTableIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Subnet. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_virtualhub_types.go
+++ b/apis/network/v1beta1/zz_virtualhub_types.go
@@ -38,15 +38,15 @@ type VirtualHubInitParameters_2 struct {
 	VirtualRouterAutoScaleMinCapacity *float64 `json:"virtualRouterAutoScaleMinCapacity,omitempty" tf:"virtual_router_auto_scale_min_capacity,omitempty"`
 
 	// The ID of a Virtual WAN within which the Virtual Hub should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualWAN
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualWAN
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VirtualWanID *string `json:"virtualWanId,omitempty" tf:"virtual_wan_id,omitempty"`
 
-	// Reference to a VirtualWAN to populate virtualWanId.
+	// Reference to a VirtualWAN in network to populate virtualWanId.
 	// +kubebuilder:validation:Optional
 	VirtualWanIDRef *v1.Reference `json:"virtualWanIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualWAN to populate virtualWanId.
+	// Selector for a VirtualWAN in network to populate virtualWanId.
 	// +kubebuilder:validation:Optional
 	VirtualWanIDSelector *v1.Selector `json:"virtualWanIdSelector,omitempty" tf:"-"`
 }
@@ -139,16 +139,16 @@ type VirtualHubParameters_2 struct {
 	VirtualRouterAutoScaleMinCapacity *float64 `json:"virtualRouterAutoScaleMinCapacity,omitempty" tf:"virtual_router_auto_scale_min_capacity,omitempty"`
 
 	// The ID of a Virtual WAN within which the Virtual Hub should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualWAN
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualWAN
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VirtualWanID *string `json:"virtualWanId,omitempty" tf:"virtual_wan_id,omitempty"`
 
-	// Reference to a VirtualWAN to populate virtualWanId.
+	// Reference to a VirtualWAN in network to populate virtualWanId.
 	// +kubebuilder:validation:Optional
 	VirtualWanIDRef *v1.Reference `json:"virtualWanIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualWAN to populate virtualWanId.
+	// Selector for a VirtualWAN in network to populate virtualWanId.
 	// +kubebuilder:validation:Optional
 	VirtualWanIDSelector *v1.Selector `json:"virtualWanIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_virtualnetworkgateway_types.go
+++ b/apis/network/v1beta1/zz_virtualnetworkgateway_types.go
@@ -598,15 +598,15 @@ type VirtualNetworkGatewayIPConfigurationInitParameters struct {
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// The ID of the gateway subnet of a virtual network in which the virtual network gateway will be created. It is mandatory that the associated subnet is named GatewaySubnet. Therefore, each virtual network can contain at most a single Virtual Network Gateway.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -651,16 +651,16 @@ type VirtualNetworkGatewayIPConfigurationParameters struct {
 	PublicIPAddressIDSelector *v1.Selector `json:"publicIpAddressIdSelector,omitempty" tf:"-"`
 
 	// The ID of the gateway subnet of a virtual network in which the virtual network gateway will be created. It is mandatory that the associated subnet is named GatewaySubnet. Therefore, each virtual network can contain at most a single Virtual Network Gateway.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Subnet
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in network to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_virtualnetworkgatewayconnection_types.go
+++ b/apis/network/v1beta1/zz_virtualnetworkgatewayconnection_types.go
@@ -130,15 +130,15 @@ type VirtualNetworkGatewayConnectionInitParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The ID of the peer virtual network gateway when creating a VNet-to-VNet connection (i.e. when type is Vnet2Vnet). The peer Virtual Network Gateway can be in the same or in a different subscription. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetworkGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetworkGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PeerVirtualNetworkGatewayID *string `json:"peerVirtualNetworkGatewayId,omitempty" tf:"peer_virtual_network_gateway_id,omitempty"`
 
-	// Reference to a VirtualNetworkGateway to populate peerVirtualNetworkGatewayId.
+	// Reference to a VirtualNetworkGateway in network to populate peerVirtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	PeerVirtualNetworkGatewayIDRef *v1.Reference `json:"peerVirtualNetworkGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetworkGateway to populate peerVirtualNetworkGatewayId.
+	// Selector for a VirtualNetworkGateway in network to populate peerVirtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	PeerVirtualNetworkGatewayIDSelector *v1.Selector `json:"peerVirtualNetworkGatewayIdSelector,omitempty" tf:"-"`
 
@@ -161,15 +161,15 @@ type VirtualNetworkGatewayConnectionInitParameters struct {
 	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty" tf:"use_policy_based_traffic_selectors,omitempty"`
 
 	// The ID of the Virtual Network Gateway in which the connection will be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetworkGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetworkGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	VirtualNetworkGatewayID *string `json:"virtualNetworkGatewayId,omitempty" tf:"virtual_network_gateway_id,omitempty"`
 
-	// Reference to a VirtualNetworkGateway to populate virtualNetworkGatewayId.
+	// Reference to a VirtualNetworkGateway in network to populate virtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkGatewayIDRef *v1.Reference `json:"virtualNetworkGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetworkGateway to populate virtualNetworkGatewayId.
+	// Selector for a VirtualNetworkGateway in network to populate virtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkGatewayIDSelector *v1.Selector `json:"virtualNetworkGatewayIdSelector,omitempty" tf:"-"`
 }
@@ -424,16 +424,16 @@ type VirtualNetworkGatewayConnectionParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The ID of the peer virtual network gateway when creating a VNet-to-VNet connection (i.e. when type is Vnet2Vnet). The peer Virtual Network Gateway can be in the same or in a different subscription. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetworkGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetworkGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PeerVirtualNetworkGatewayID *string `json:"peerVirtualNetworkGatewayId,omitempty" tf:"peer_virtual_network_gateway_id,omitempty"`
 
-	// Reference to a VirtualNetworkGateway to populate peerVirtualNetworkGatewayId.
+	// Reference to a VirtualNetworkGateway in network to populate peerVirtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	PeerVirtualNetworkGatewayIDRef *v1.Reference `json:"peerVirtualNetworkGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetworkGateway to populate peerVirtualNetworkGatewayId.
+	// Selector for a VirtualNetworkGateway in network to populate peerVirtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	PeerVirtualNetworkGatewayIDSelector *v1.Selector `json:"peerVirtualNetworkGatewayIdSelector,omitempty" tf:"-"`
 
@@ -478,16 +478,16 @@ type VirtualNetworkGatewayConnectionParameters struct {
 	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty" tf:"use_policy_based_traffic_selectors,omitempty"`
 
 	// The ID of the Virtual Network Gateway in which the connection will be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetworkGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetworkGateway
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	VirtualNetworkGatewayID *string `json:"virtualNetworkGatewayId,omitempty" tf:"virtual_network_gateway_id,omitempty"`
 
-	// Reference to a VirtualNetworkGateway to populate virtualNetworkGatewayId.
+	// Reference to a VirtualNetworkGateway in network to populate virtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkGatewayIDRef *v1.Reference `json:"virtualNetworkGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetworkGateway to populate virtualNetworkGatewayId.
+	// Selector for a VirtualNetworkGateway in network to populate virtualNetworkGatewayId.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkGatewayIDSelector *v1.Selector `json:"virtualNetworkGatewayIdSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_virtualnetworkpeering_types.go
+++ b/apis/network/v1beta1/zz_virtualnetworkpeering_types.go
@@ -25,15 +25,15 @@ type VirtualNetworkPeeringInitParameters struct {
 	AllowVirtualNetworkAccess *bool `json:"allowVirtualNetworkAccess,omitempty" tf:"allow_virtual_network_access,omitempty"`
 
 	// The full Azure resource ID of the remote virtual network. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	RemoteVirtualNetworkID *string `json:"remoteVirtualNetworkId,omitempty" tf:"remote_virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate remoteVirtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate remoteVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	RemoteVirtualNetworkIDRef *v1.Reference `json:"remoteVirtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate remoteVirtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate remoteVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	RemoteVirtualNetworkIDSelector *v1.Selector `json:"remoteVirtualNetworkIdSelector,omitempty" tf:"-"`
 
@@ -91,16 +91,16 @@ type VirtualNetworkPeeringParameters struct {
 	AllowVirtualNetworkAccess *bool `json:"allowVirtualNetworkAccess,omitempty" tf:"allow_virtual_network_access,omitempty"`
 
 	// The full Azure resource ID of the remote virtual network. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	RemoteVirtualNetworkID *string `json:"remoteVirtualNetworkId,omitempty" tf:"remote_virtual_network_id,omitempty"`
 
-	// Reference to a VirtualNetwork to populate remoteVirtualNetworkId.
+	// Reference to a VirtualNetwork in network to populate remoteVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	RemoteVirtualNetworkIDRef *v1.Reference `json:"remoteVirtualNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate remoteVirtualNetworkId.
+	// Selector for a VirtualNetwork in network to populate remoteVirtualNetworkId.
 	// +kubebuilder:validation:Optional
 	RemoteVirtualNetworkIDSelector *v1.Selector `json:"remoteVirtualNetworkIdSelector,omitempty" tf:"-"`
 
@@ -127,15 +127,15 @@ type VirtualNetworkPeeringParameters struct {
 	UseRemoteGateways *bool `json:"useRemoteGateways,omitempty" tf:"use_remote_gateways,omitempty"`
 
 	// The name of the virtual network. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=VirtualNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.VirtualNetwork
 	// +kubebuilder:validation:Optional
 	VirtualNetworkName *string `json:"virtualNetworkName,omitempty" tf:"virtual_network_name,omitempty"`
 
-	// Reference to a VirtualNetwork to populate virtualNetworkName.
+	// Reference to a VirtualNetwork in network to populate virtualNetworkName.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkNameRef *v1.Reference `json:"virtualNetworkNameRef,omitempty" tf:"-"`
 
-	// Selector for a VirtualNetwork to populate virtualNetworkName.
+	// Selector for a VirtualNetwork in network to populate virtualNetworkName.
 	// +kubebuilder:validation:Optional
 	VirtualNetworkNameSelector *v1.Selector `json:"virtualNetworkNameSelector,omitempty" tf:"-"`
 }

--- a/apis/network/v1beta1/zz_watcherflowlog_types.go
+++ b/apis/network/v1beta1/zz_watcherflowlog_types.go
@@ -150,15 +150,15 @@ type WatcherFlowLogInitParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The ID of the Network Security Group for which to enable flow logs for. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty" tf:"network_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupId.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDRef *v1.Reference `json:"networkSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupId.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDSelector *v1.Selector `json:"networkSecurityGroupIdSelector,omitempty" tf:"-"`
 
@@ -237,29 +237,29 @@ type WatcherFlowLogParameters struct {
 	Location *string `json:"location,omitempty" tf:"location,omitempty"`
 
 	// The ID of the Network Security Group for which to enable flow logs for. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty" tf:"network_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate networkSecurityGroupId.
+	// Reference to a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDRef *v1.Reference `json:"networkSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate networkSecurityGroupId.
+	// Selector for a SecurityGroup in network to populate networkSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	NetworkSecurityGroupIDSelector *v1.Selector `json:"networkSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// The name of the Network Watcher. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Watcher
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/network/v1beta1.Watcher
 	// +kubebuilder:validation:Optional
 	NetworkWatcherName *string `json:"networkWatcherName,omitempty" tf:"network_watcher_name,omitempty"`
 
-	// Reference to a Watcher to populate networkWatcherName.
+	// Reference to a Watcher in network to populate networkWatcherName.
 	// +kubebuilder:validation:Optional
 	NetworkWatcherNameRef *v1.Reference `json:"networkWatcherNameRef,omitempty" tf:"-"`
 
-	// Selector for a Watcher to populate networkWatcherName.
+	// Selector for a Watcher in network to populate networkWatcherName.
 	// +kubebuilder:validation:Optional
 	NetworkWatcherNameSelector *v1.Selector `json:"networkWatcherNameSelector,omitempty" tf:"-"`
 

--- a/apis/rconfig/config.go
+++ b/apis/rconfig/config.go
@@ -5,8 +5,6 @@
 package rconfig
 
 import (
-	"fmt"
-
 	"github.com/crossplane/upjet/pkg/resource"
 
 	xpref "github.com/crossplane/crossplane-runtime/pkg/reference"
@@ -18,28 +16,7 @@ const (
 	APISPackagePath = "github.com/upbound/provider-azure/apis"
 	// ExtractResourceIDFuncPath holds the Azure resource ID extractor func name
 	ExtractResourceIDFuncPath = APISPackagePath + "/rconfig.ExtractResourceID()"
-
-	// VersionV1Alpha2 is used as minimum version for all manually configured resources.
-	// Deprecated: Please use VersionV1Beta1 as minimum.
-	VersionV1Alpha2 = "v1alpha2"
-	// VersionV1Beta1 is used to signify that the resource has been tested and external name configured
-	VersionV1Beta1 = "v1beta1"
-
-	// StorageAccountReferencePath is used as import path for StorageAccount
-	StorageAccountReferencePath = APISPackagePath + "/storage/" + VersionV1Beta1 + ".Account"
-
-	// VaultKeyReferencePath is used as import path for VaultKey
-	VaultKeyReferencePath = APISPackagePath + "/keyvault/" + VersionV1Beta1 + ".Key"
-
-	// ContainerReferencePath is used as import path for Container
-	ContainerReferencePath = APISPackagePath + "/storage/" + VersionV1Beta1 + ".Container"
 )
-
-// GetDefaultVersionedPath gets the package path from repo root
-// for the specified group and kind name.
-func GetDefaultVersionedPath(group, kindName string) string {
-	return fmt.Sprintf("/%s/%s.%s", group, VersionV1Beta1, kindName)
-}
 
 // ExtractResourceID extracts the value of `spec.atProvider.id`
 // from a Terraformed resource. If mr is not a Terraformed

--- a/apis/sql/v1beta1/zz_mssqldatabase_types.go
+++ b/apis/sql/v1beta1/zz_mssqldatabase_types.go
@@ -482,16 +482,16 @@ type MSSQLDatabaseParameters struct {
 	SampleName *string `json:"sampleName,omitempty" tf:"sample_name,omitempty"`
 
 	// The id of the MS SQL Server on which to create the database. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverId.
+	// Reference to a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverId.
+	// Selector for a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqldatabasevulnerabilityassessmentrulebaseline_types.go
+++ b/apis/sql/v1beta1/zz_mssqldatabasevulnerabilityassessmentrulebaseline_types.go
@@ -41,14 +41,14 @@ type MSSQLDatabaseVulnerabilityAssessmentRuleBaselineInitParameters struct {
 	BaselineResult []BaselineResultInitParameters `json:"baselineResult,omitempty" tf:"baseline_result,omitempty"`
 
 	// Specifies the name of the MS SQL Database. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLDatabase
 	DatabaseName *string `json:"databaseName,omitempty" tf:"database_name,omitempty"`
 
-	// Reference to a MSSQLDatabase to populate databaseName.
+	// Reference to a MSSQLDatabase in sql to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameRef *v1.Reference `json:"databaseNameRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLDatabase to populate databaseName.
+	// Selector for a MSSQLDatabase in sql to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameSelector *v1.Selector `json:"databaseNameSelector,omitempty" tf:"-"`
 
@@ -101,15 +101,15 @@ type MSSQLDatabaseVulnerabilityAssessmentRuleBaselineParameters struct {
 	BaselineResult []BaselineResultParameters `json:"baselineResult,omitempty" tf:"baseline_result,omitempty"`
 
 	// Specifies the name of the MS SQL Database. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLDatabase
 	// +kubebuilder:validation:Optional
 	DatabaseName *string `json:"databaseName,omitempty" tf:"database_name,omitempty"`
 
-	// Reference to a MSSQLDatabase to populate databaseName.
+	// Reference to a MSSQLDatabase in sql to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameRef *v1.Reference `json:"databaseNameRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLDatabase to populate databaseName.
+	// Selector for a MSSQLDatabase in sql to populate databaseName.
 	// +kubebuilder:validation:Optional
 	DatabaseNameSelector *v1.Selector `json:"databaseNameSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlelasticpool_types.go
+++ b/apis/sql/v1beta1/zz_mssqlelasticpool_types.go
@@ -134,15 +134,15 @@ type MSSQLElasticPoolParameters struct {
 	ResourceGroupNameSelector *v1.Selector `json:"resourceGroupNameSelector,omitempty" tf:"-"`
 
 	// The name of the SQL Server on which to create the elastic pool. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverName.
+	// Reference to a MSSQLServer in sql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverName.
+	// Selector for a MSSQLServer in sql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlfailovergroup_types.go
+++ b/apis/sql/v1beta1/zz_mssqlfailovergroup_types.go
@@ -16,16 +16,16 @@ import (
 type MSSQLFailoverGroupInitParameters struct {
 
 	// A set of database names to include in the failover group.
-	// +crossplane:generate:reference:type=MSSQLDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLDatabase
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +listType=set
 	Databases []*string `json:"databases,omitempty" tf:"databases,omitempty"`
 
-	// References to MSSQLDatabase to populate databases.
+	// References to MSSQLDatabase in sql to populate databases.
 	// +kubebuilder:validation:Optional
 	DatabasesRefs []v1.Reference `json:"databasesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of MSSQLDatabase to populate databases.
+	// Selector for a list of MSSQLDatabase in sql to populate databases.
 	// +kubebuilder:validation:Optional
 	DatabasesSelector *v1.Selector `json:"databasesSelector,omitempty" tf:"-"`
 
@@ -72,17 +72,17 @@ type MSSQLFailoverGroupObservation struct {
 type MSSQLFailoverGroupParameters struct {
 
 	// A set of database names to include in the failover group.
-	// +crossplane:generate:reference:type=MSSQLDatabase
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLDatabase
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	Databases []*string `json:"databases,omitempty" tf:"databases,omitempty"`
 
-	// References to MSSQLDatabase to populate databases.
+	// References to MSSQLDatabase in sql to populate databases.
 	// +kubebuilder:validation:Optional
 	DatabasesRefs []v1.Reference `json:"databasesRefs,omitempty" tf:"-"`
 
-	// Selector for a list of MSSQLDatabase to populate databases.
+	// Selector for a list of MSSQLDatabase in sql to populate databases.
 	// +kubebuilder:validation:Optional
 	DatabasesSelector *v1.Selector `json:"databasesSelector,omitempty" tf:"-"`
 
@@ -99,16 +99,16 @@ type MSSQLFailoverGroupParameters struct {
 	ReadonlyEndpointFailoverPolicyEnabled *bool `json:"readonlyEndpointFailoverPolicyEnabled,omitempty" tf:"readonly_endpoint_failover_policy_enabled,omitempty"`
 
 	// The ID of the primary SQL Server on which to create the failover group. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverId.
+	// Reference to a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverId.
+	// Selector for a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 
@@ -121,15 +121,15 @@ type MSSQLFailoverGroupParameters struct {
 type PartnerServerInitParameters struct {
 
 	// The ID of a partner SQL server to include in the failover group.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// Reference to a MSSQLServer to populate id.
+	// Reference to a MSSQLServer in sql to populate id.
 	// +kubebuilder:validation:Optional
 	IDRef *v1.Reference `json:"idRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate id.
+	// Selector for a MSSQLServer in sql to populate id.
 	// +kubebuilder:validation:Optional
 	IDSelector *v1.Selector `json:"idSelector,omitempty" tf:"-"`
 }
@@ -149,16 +149,16 @@ type PartnerServerObservation struct {
 type PartnerServerParameters struct {
 
 	// The ID of a partner SQL server to include in the failover group.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// Reference to a MSSQLServer to populate id.
+	// Reference to a MSSQLServer in sql to populate id.
 	// +kubebuilder:validation:Optional
 	IDRef *v1.Reference `json:"idRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate id.
+	// Selector for a MSSQLServer in sql to populate id.
 	// +kubebuilder:validation:Optional
 	IDSelector *v1.Selector `json:"idSelector,omitempty" tf:"-"`
 }

--- a/apis/sql/v1beta1/zz_mssqlmanageddatabase_types.go
+++ b/apis/sql/v1beta1/zz_mssqlmanageddatabase_types.go
@@ -109,16 +109,16 @@ type MSSQLManagedDatabaseParameters struct {
 	LongTermRetentionPolicy []MSSQLManagedDatabaseLongTermRetentionPolicyParameters `json:"longTermRetentionPolicy,omitempty" tf:"long_term_retention_policy,omitempty"`
 
 	// The ID of the Azure SQL Managed Instance on which to create this Managed Database. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ManagedInstanceID *string `json:"managedInstanceId,omitempty" tf:"managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate managedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDRef *v1.Reference `json:"managedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate managedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDSelector *v1.Selector `json:"managedInstanceIdSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlmanagedinstance_types.go
+++ b/apis/sql/v1beta1/zz_mssqlmanagedinstance_types.go
@@ -60,15 +60,15 @@ type MSSQLManagedInstanceInitParameters struct {
 	Collation *string `json:"collation,omitempty" tf:"collation,omitempty"`
 
 	// The ID of the SQL Managed Instance which will share the DNS zone. This is a prerequisite for creating an azurerm_sql_managed_instance_failover_group. Setting this after creation forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	DNSZonePartnerID *string `json:"dnsZonePartnerId,omitempty" tf:"dns_zone_partner_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate dnsZonePartnerId.
+	// Reference to a MSSQLManagedInstance in sql to populate dnsZonePartnerId.
 	// +kubebuilder:validation:Optional
 	DNSZonePartnerIDRef *v1.Reference `json:"dnsZonePartnerIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate dnsZonePartnerId.
+	// Selector for a MSSQLManagedInstance in sql to populate dnsZonePartnerId.
 	// +kubebuilder:validation:Optional
 	DNSZonePartnerIDSelector *v1.Selector `json:"dnsZonePartnerIdSelector,omitempty" tf:"-"`
 
@@ -214,16 +214,16 @@ type MSSQLManagedInstanceParameters struct {
 	Collation *string `json:"collation,omitempty" tf:"collation,omitempty"`
 
 	// The ID of the SQL Managed Instance which will share the DNS zone. This is a prerequisite for creating an azurerm_sql_managed_instance_failover_group. Setting this after creation forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	DNSZonePartnerID *string `json:"dnsZonePartnerId,omitempty" tf:"dns_zone_partner_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate dnsZonePartnerId.
+	// Reference to a MSSQLManagedInstance in sql to populate dnsZonePartnerId.
 	// +kubebuilder:validation:Optional
 	DNSZonePartnerIDRef *v1.Reference `json:"dnsZonePartnerIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate dnsZonePartnerId.
+	// Selector for a MSSQLManagedInstance in sql to populate dnsZonePartnerId.
 	// +kubebuilder:validation:Optional
 	DNSZonePartnerIDSelector *v1.Selector `json:"dnsZonePartnerIdSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlmanagedinstanceactivedirectoryadministrator_types.go
+++ b/apis/sql/v1beta1/zz_mssqlmanagedinstanceactivedirectoryadministrator_types.go
@@ -60,16 +60,16 @@ type MSSQLManagedInstanceActiveDirectoryAdministratorParameters struct {
 	LoginUsername *string `json:"loginUsername,omitempty" tf:"login_username,omitempty"`
 
 	// The ID of the Azure SQL Managed Instance for which to set the administrator. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ManagedInstanceID *string `json:"managedInstanceId,omitempty" tf:"managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate managedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDRef *v1.Reference `json:"managedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate managedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDSelector *v1.Selector `json:"managedInstanceIdSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlmanagedinstancefailovergroup_types.go
+++ b/apis/sql/v1beta1/zz_mssqlmanagedinstancefailovergroup_types.go
@@ -16,28 +16,28 @@ import (
 type MSSQLManagedInstanceFailoverGroupInitParameters struct {
 
 	// The ID of the Azure SQL Managed Instance which will be replicated using a Managed Instance Failover Group. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	ManagedInstanceID *string `json:"managedInstanceId,omitempty" tf:"managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate managedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDRef *v1.Reference `json:"managedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate managedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDSelector *v1.Selector `json:"managedInstanceIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Azure SQL Managed Instance which will be replicated to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	PartnerManagedInstanceID *string `json:"partnerManagedInstanceId,omitempty" tf:"partner_managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate partnerManagedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate partnerManagedInstanceId.
 	// +kubebuilder:validation:Optional
 	PartnerManagedInstanceIDRef *v1.Reference `json:"partnerManagedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate partnerManagedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate partnerManagedInstanceId.
 	// +kubebuilder:validation:Optional
 	PartnerManagedInstanceIDSelector *v1.Selector `json:"partnerManagedInstanceIdSelector,omitempty" tf:"-"`
 
@@ -82,30 +82,30 @@ type MSSQLManagedInstanceFailoverGroupParameters struct {
 	Location *string `json:"location" tf:"location,omitempty"`
 
 	// The ID of the Azure SQL Managed Instance which will be replicated using a Managed Instance Failover Group. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ManagedInstanceID *string `json:"managedInstanceId,omitempty" tf:"managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate managedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDRef *v1.Reference `json:"managedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate managedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDSelector *v1.Selector `json:"managedInstanceIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Azure SQL Managed Instance which will be replicated to. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	PartnerManagedInstanceID *string `json:"partnerManagedInstanceId,omitempty" tf:"partner_managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate partnerManagedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate partnerManagedInstanceId.
 	// +kubebuilder:validation:Optional
 	PartnerManagedInstanceIDRef *v1.Reference `json:"partnerManagedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate partnerManagedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate partnerManagedInstanceId.
 	// +kubebuilder:validation:Optional
 	PartnerManagedInstanceIDSelector *v1.Selector `json:"partnerManagedInstanceIdSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlmanagedinstancevulnerabilityassessment_types.go
+++ b/apis/sql/v1beta1/zz_mssqlmanagedinstancevulnerabilityassessment_types.go
@@ -40,16 +40,16 @@ type MSSQLManagedInstanceVulnerabilityAssessmentObservation struct {
 type MSSQLManagedInstanceVulnerabilityAssessmentParameters struct {
 
 	// The id of the MS SQL Managed Instance. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLManagedInstance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLManagedInstance
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ManagedInstanceID *string `json:"managedInstanceId,omitempty" tf:"managed_instance_id,omitempty"`
 
-	// Reference to a MSSQLManagedInstance to populate managedInstanceId.
+	// Reference to a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDRef *v1.Reference `json:"managedInstanceIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLManagedInstance to populate managedInstanceId.
+	// Selector for a MSSQLManagedInstance in sql to populate managedInstanceId.
 	// +kubebuilder:validation:Optional
 	ManagedInstanceIDSelector *v1.Selector `json:"managedInstanceIdSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqloutboundfirewallrule_types.go
+++ b/apis/sql/v1beta1/zz_mssqloutboundfirewallrule_types.go
@@ -28,16 +28,16 @@ type MSSQLOutboundFirewallRuleObservation struct {
 type MSSQLOutboundFirewallRuleParameters struct {
 
 	// The resource ID of the SQL Server on which to create the Outbound Firewall Rule. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverId.
+	// Reference to a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverId.
+	// Selector for a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 }

--- a/apis/sql/v1beta1/zz_mssqlserverdnsalias_types.go
+++ b/apis/sql/v1beta1/zz_mssqlserverdnsalias_types.go
@@ -31,16 +31,16 @@ type MSSQLServerDNSAliasObservation struct {
 type MSSQLServerDNSAliasParameters struct {
 
 	// The ID of the mssql server. Changing this forces a new MSSQL Server DNS Alias to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	MSSQLServerID *string `json:"mssqlServerId,omitempty" tf:"mssql_server_id,omitempty"`
 
-	// Reference to a MSSQLServer to populate mssqlServerId.
+	// Reference to a MSSQLServer in sql to populate mssqlServerId.
 	// +kubebuilder:validation:Optional
 	MSSQLServerIDRef *v1.Reference `json:"mssqlServerIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate mssqlServerId.
+	// Selector for a MSSQLServer in sql to populate mssqlServerId.
 	// +kubebuilder:validation:Optional
 	MSSQLServerIDSelector *v1.Selector `json:"mssqlServerIdSelector,omitempty" tf:"-"`
 }

--- a/apis/sql/v1beta1/zz_mssqlserversecurityalertpolicy_types.go
+++ b/apis/sql/v1beta1/zz_mssqlserversecurityalertpolicy_types.go
@@ -112,15 +112,15 @@ type MSSQLServerSecurityAlertPolicyParameters struct {
 	RetentionDays *float64 `json:"retentionDays,omitempty" tf:"retention_days,omitempty"`
 
 	// Specifies the name of the MS SQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +kubebuilder:validation:Optional
 	ServerName *string `json:"serverName,omitempty" tf:"server_name,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverName.
+	// Reference to a MSSQLServer in sql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameRef *v1.Reference `json:"serverNameRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverName.
+	// Selector for a MSSQLServer in sql to populate serverName.
 	// +kubebuilder:validation:Optional
 	ServerNameSelector *v1.Selector `json:"serverNameSelector,omitempty" tf:"-"`
 

--- a/apis/sql/v1beta1/zz_mssqlservertransparentdataencryption_types.go
+++ b/apis/sql/v1beta1/zz_mssqlservertransparentdataencryption_types.go
@@ -68,16 +68,16 @@ type MSSQLServerTransparentDataEncryptionParameters struct {
 	KeyVaultKeyIDSelector *v1.Selector `json:"keyVaultKeyIdSelector,omitempty" tf:"-"`
 
 	// Specifies the name of the MS SQL Server. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverId.
+	// Reference to a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverId.
+	// Selector for a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 }

--- a/apis/sql/v1beta1/zz_mssqlvirtualnetworkrule_types.go
+++ b/apis/sql/v1beta1/zz_mssqlvirtualnetworkrule_types.go
@@ -54,16 +54,16 @@ type MSSQLVirtualNetworkRuleParameters struct {
 	IgnoreMissingVnetServiceEndpoint *bool `json:"ignoreMissingVnetServiceEndpoint,omitempty" tf:"ignore_missing_vnet_service_endpoint,omitempty"`
 
 	// The resource ID of the SQL Server to which this SQL virtual network rule will be applied. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=MSSQLServer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a MSSQLServer to populate serverId.
+	// Reference to a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a MSSQLServer to populate serverId.
+	// Selector for a MSSQLServer in sql to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 

--- a/apis/storage/v1beta1/zz_blob_types.go
+++ b/apis/storage/v1beta1/zz_blob_types.go
@@ -143,28 +143,28 @@ type BlobParameters struct {
 	SourceURI *string `json:"sourceUri,omitempty" tf:"source_uri,omitempty"`
 
 	// Specifies the storage account in which to create the storage container. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/storage/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	StorageAccountName *string `json:"storageAccountName,omitempty" tf:"storage_account_name,omitempty"`
 
-	// Reference to a Account to populate storageAccountName.
+	// Reference to a Account in storage to populate storageAccountName.
 	// +kubebuilder:validation:Optional
 	StorageAccountNameRef *v1.Reference `json:"storageAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate storageAccountName.
+	// Selector for a Account in storage to populate storageAccountName.
 	// +kubebuilder:validation:Optional
 	StorageAccountNameSelector *v1.Selector `json:"storageAccountNameSelector,omitempty" tf:"-"`
 
 	// The name of the storage container in which this blob should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Container
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/storage/v1beta1.Container
 	// +kubebuilder:validation:Optional
 	StorageContainerName *string `json:"storageContainerName,omitempty" tf:"storage_container_name,omitempty"`
 
-	// Reference to a Container to populate storageContainerName.
+	// Reference to a Container in storage to populate storageContainerName.
 	// +kubebuilder:validation:Optional
 	StorageContainerNameRef *v1.Reference `json:"storageContainerNameRef,omitempty" tf:"-"`
 
-	// Selector for a Container to populate storageContainerName.
+	// Selector for a Container in storage to populate storageContainerName.
 	// +kubebuilder:validation:Optional
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 

--- a/apis/storage/v1beta1/zz_container_types.go
+++ b/apis/storage/v1beta1/zz_container_types.go
@@ -60,15 +60,15 @@ type ContainerParameters struct {
 	Metadata map[string]*string `json:"metadata,omitempty" tf:"metadata,omitempty"`
 
 	// The name of the Storage Account where the Container should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/storage/v1beta1.Account
 	// +kubebuilder:validation:Optional
 	StorageAccountName *string `json:"storageAccountName,omitempty" tf:"storage_account_name,omitempty"`
 
-	// Reference to a Account to populate storageAccountName.
+	// Reference to a Account in storage to populate storageAccountName.
 	// +kubebuilder:validation:Optional
 	StorageAccountNameRef *v1.Reference `json:"storageAccountNameRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate storageAccountName.
+	// Selector for a Account in storage to populate storageAccountName.
 	// +kubebuilder:validation:Optional
 	StorageAccountNameSelector *v1.Selector `json:"storageAccountNameSelector,omitempty" tf:"-"`
 }

--- a/apis/storage/v1beta1/zz_datalakegen2filesystem_types.go
+++ b/apis/storage/v1beta1/zz_datalakegen2filesystem_types.go
@@ -78,15 +78,15 @@ type DataLakeGen2FileSystemInitParameters struct {
 	Properties map[string]*string `json:"properties,omitempty" tf:"properties,omitempty"`
 
 	// Specifies the ID of the Storage Account in which the Data Lake Gen2 File System should exist. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/storage/v1beta1.Account
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	StorageAccountID *string `json:"storageAccountId,omitempty" tf:"storage_account_id,omitempty"`
 
-	// Reference to a Account to populate storageAccountId.
+	// Reference to a Account in storage to populate storageAccountId.
 	// +kubebuilder:validation:Optional
 	StorageAccountIDRef *v1.Reference `json:"storageAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate storageAccountId.
+	// Selector for a Account in storage to populate storageAccountId.
 	// +kubebuilder:validation:Optional
 	StorageAccountIDSelector *v1.Selector `json:"storageAccountIdSelector,omitempty" tf:"-"`
 }
@@ -133,16 +133,16 @@ type DataLakeGen2FileSystemParameters struct {
 	Properties map[string]*string `json:"properties,omitempty" tf:"properties,omitempty"`
 
 	// Specifies the ID of the Storage Account in which the Data Lake Gen2 File System should exist. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Account
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/storage/v1beta1.Account
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	StorageAccountID *string `json:"storageAccountId,omitempty" tf:"storage_account_id,omitempty"`
 
-	// Reference to a Account to populate storageAccountId.
+	// Reference to a Account in storage to populate storageAccountId.
 	// +kubebuilder:validation:Optional
 	StorageAccountIDRef *v1.Reference `json:"storageAccountIdRef,omitempty" tf:"-"`
 
-	// Selector for a Account to populate storageAccountId.
+	// Selector for a Account in storage to populate storageAccountId.
 	// +kubebuilder:validation:Optional
 	StorageAccountIDSelector *v1.Selector `json:"storageAccountIdSelector,omitempty" tf:"-"`
 }

--- a/apis/streamanalytics/v1beta1/zz_functionjavascriptuda_types.go
+++ b/apis/streamanalytics/v1beta1/zz_functionjavascriptuda_types.go
@@ -25,15 +25,15 @@ type FunctionJavascriptUdaInitParameters struct {
 	Script *string `json:"script,omitempty" tf:"script,omitempty"`
 
 	// The resource ID of the Stream Analytics Job where this Function should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	StreamAnalyticsJobID *string `json:"streamAnalyticsJobId,omitempty" tf:"stream_analytics_job_id,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobId.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDRef *v1.Reference `json:"streamAnalyticsJobIdRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobId.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDSelector *v1.Selector `json:"streamAnalyticsJobIdSelector,omitempty" tf:"-"`
 }
@@ -71,16 +71,16 @@ type FunctionJavascriptUdaParameters struct {
 	Script *string `json:"script,omitempty" tf:"script,omitempty"`
 
 	// The resource ID of the Stream Analytics Job where this Function should be created. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobID *string `json:"streamAnalyticsJobId,omitempty" tf:"stream_analytics_job_id,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobId.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDRef *v1.Reference `json:"streamAnalyticsJobIdRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobId.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDSelector *v1.Selector `json:"streamAnalyticsJobIdSelector,omitempty" tf:"-"`
 }

--- a/apis/streamanalytics/v1beta1/zz_outputblob_types.go
+++ b/apis/streamanalytics/v1beta1/zz_outputblob_types.go
@@ -61,14 +61,14 @@ type OutputBlobInitParameters struct {
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 
@@ -192,15 +192,15 @@ type OutputBlobParameters struct {
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_outputmssql_types.go
+++ b/apis/streamanalytics/v1beta1/zz_outputmssql_types.go
@@ -55,14 +55,14 @@ type OutputMSSQLInitParameters struct {
 	ServerSelector *v1.Selector `json:"serverSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 
@@ -171,15 +171,15 @@ type OutputMSSQLParameters struct {
 	ServerSelector *v1.Selector `json:"serverSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_outputpowerbi_types.go
+++ b/apis/streamanalytics/v1beta1/zz_outputpowerbi_types.go
@@ -25,15 +25,15 @@ type OutputPowerBIInitParameters struct {
 	GroupName *string `json:"groupName,omitempty" tf:"group_name,omitempty"`
 
 	// The ID of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	StreamAnalyticsJobID *string `json:"streamAnalyticsJobId,omitempty" tf:"stream_analytics_job_id,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobId.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDRef *v1.Reference `json:"streamAnalyticsJobIdRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobId.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDSelector *v1.Selector `json:"streamAnalyticsJobIdSelector,omitempty" tf:"-"`
 
@@ -88,16 +88,16 @@ type OutputPowerBIParameters struct {
 	GroupName *string `json:"groupName,omitempty" tf:"group_name,omitempty"`
 
 	// The ID of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobID *string `json:"streamAnalyticsJobId,omitempty" tf:"stream_analytics_job_id,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobId.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDRef *v1.Reference `json:"streamAnalyticsJobIdRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobId.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobId.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobIDSelector *v1.Selector `json:"streamAnalyticsJobIdSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_outputservicebusqueue_types.go
+++ b/apis/streamanalytics/v1beta1/zz_outputservicebusqueue_types.go
@@ -67,14 +67,14 @@ type OutputServiceBusQueueInitParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 
@@ -186,15 +186,15 @@ type OutputServiceBusQueueParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_outputservicebustopic_types.go
+++ b/apis/streamanalytics/v1beta1/zz_outputservicebustopic_types.go
@@ -55,14 +55,14 @@ type OutputServiceBusTopicInitParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 
@@ -173,15 +173,15 @@ type OutputServiceBusTopicParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_outputsynapse_types.go
+++ b/apis/streamanalytics/v1beta1/zz_outputsynapse_types.go
@@ -90,15 +90,15 @@ type OutputSynapseParameters struct {
 	Server *string `json:"server,omitempty" tf:"server,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_referenceinputblob_types.go
+++ b/apis/streamanalytics/v1beta1/zz_referenceinputblob_types.go
@@ -67,14 +67,14 @@ type ReferenceInputBlobInitParameters struct {
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 
@@ -184,15 +184,15 @@ type ReferenceInputBlobParameters struct {
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_streaminputblob_types.go
+++ b/apis/streamanalytics/v1beta1/zz_streaminputblob_types.go
@@ -64,14 +64,14 @@ type StreamInputBlobInitParameters struct {
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 
@@ -174,15 +174,15 @@ type StreamInputBlobParameters struct {
 	StorageContainerNameSelector *v1.Selector `json:"storageContainerNameSelector,omitempty" tf:"-"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 

--- a/apis/streamanalytics/v1beta1/zz_streaminputeventhub_types.go
+++ b/apis/streamanalytics/v1beta1/zz_streaminputeventhub_types.go
@@ -79,14 +79,14 @@ type StreamInputEventHubInitParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 }
@@ -206,15 +206,15 @@ type StreamInputEventHubParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 }

--- a/apis/streamanalytics/v1beta1/zz_streaminputiothub_types.go
+++ b/apis/streamanalytics/v1beta1/zz_streaminputiothub_types.go
@@ -64,14 +64,14 @@ type StreamInputIOTHubInitParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 }
@@ -168,15 +168,15 @@ type StreamInputIOTHubParameters struct {
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty" tf:"shared_access_policy_name,omitempty"`
 
 	// The name of the Stream Analytics Job. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=Job
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/streamanalytics/v1beta1.Job
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobName *string `json:"streamAnalyticsJobName,omitempty" tf:"stream_analytics_job_name,omitempty"`
 
-	// Reference to a Job to populate streamAnalyticsJobName.
+	// Reference to a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameRef *v1.Reference `json:"streamAnalyticsJobNameRef,omitempty" tf:"-"`
 
-	// Selector for a Job to populate streamAnalyticsJobName.
+	// Selector for a Job in streamanalytics to populate streamAnalyticsJobName.
 	// +kubebuilder:validation:Optional
 	StreamAnalyticsJobNameSelector *v1.Selector `json:"streamAnalyticsJobNameSelector,omitempty" tf:"-"`
 }

--- a/config/alertsmanagement/config.go
+++ b/config/alertsmanagement/config.go
@@ -14,28 +14,28 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_monitor_smart_detector_alert_rule", func(r *config.Resource) {
 		r.References["action_group.ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_monitor_action_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["scope_resource_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/insights/v1beta1.ApplicationInsights",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_application_insights",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("azurerm_monitor_alert_processing_rule_action_group", func(r *config.Resource) {
 		r.References["add_action_group_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_monitor_action_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["scopes"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/azure/v1beta1.ResourceGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_resource_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("azurerm_monitor_alert_processing_rule_suppression", func(r *config.Resource) {
 		r.References["scopes"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/azure/v1beta1.ResourceGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_resource_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/apimanagement/config.go
+++ b/config/apimanagement/config.go
@@ -24,73 +24,73 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("azurerm_api_management_api_operation", func(r *config.Resource) {
 		r.References["api_name"] = config.Reference{
-			Type: "API",
+			TerraformName: "azurerm_api_management_api",
 		}
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_api_policy", func(r *config.Resource) {
 		r.References["api_name"] = config.Reference{
-			Type: "API",
+			TerraformName: "azurerm_api_management_api",
 		}
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_api_schema", func(r *config.Resource) {
 		r.References["api_name"] = config.Reference{
-			Type: "API",
+			TerraformName: "azurerm_api_management_api",
 		}
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_product_api", func(r *config.Resource) {
 		r.References["api_name"] = config.Reference{
-			Type: "API",
+			TerraformName: "azurerm_api_management_api",
 		}
 		r.References["product_id"] = config.Reference{
-			Type: "Product",
+			TerraformName: "azurerm_api_management_product",
 		}
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_product_policy", func(r *config.Resource) {
 		r.References["product_id"] = config.Reference{
-			Type: "Product",
+			TerraformName: "azurerm_api_management_product",
 		}
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_subscription", func(r *config.Resource) {
 		r.References["user_id"] = config.Reference{
-			Type:      "User",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_api_management_user",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["product_id"] = config.Reference{
-			Type:      "Product",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_api_management_product",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_authorization_server", func(r *config.Resource) {
 		r.References["api_management_name"] = config.Reference{
-			Type: "Management",
+			TerraformName: "azurerm_api_management",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_api_management_gateway_api", func(r *config.Resource) {
 		r.References["gateway_id"] = config.Reference{
-			Type:      "Gateway",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_api_management_gateway",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["api_id"] = config.Reference{
-			Type:      "API",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_api_management_api",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 
 		r.TerraformCustomDiff = apiIdCustomDiff

--- a/config/appplatform/config.go
+++ b/config/appplatform/config.go
@@ -12,8 +12,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_spring_cloud_api_portal", func(r *config.Resource) {
 		r.References["gateway_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/appplatform/v1beta1.SpringCloudGateway",
-			Extractor: "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
+			TerraformName: "azurerm_spring_cloud_gateway",
+			Extractor:     "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
 		}
 	})
 }

--- a/config/cache/config.go
+++ b/config/cache/config.go
@@ -14,11 +14,11 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_redis_linked_server", func(r *config.Resource) {
 		r.References["linked_redis_cache_id"] = config.Reference{
-			Type:      "RedisCache",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_redis_cache",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["target_redis_cache_name"] = config.Reference{
-			Type: "RedisCache",
+			TerraformName: "azurerm_redis_cache",
 		}
 		delete(r.References, "linked_redis_cache_location")
 	})

--- a/config/cdn/config.go
+++ b/config/cdn/config.go
@@ -17,22 +17,22 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("azurerm_cdn_frontdoor_route", func(r *config.Resource) {
 		r.References["cdn_frontdoor_origin_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/cdn/v1beta1.FrontdoorOrigin",
-			Extractor: "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
+			TerraformName: "azurerm_cdn_frontdoor_origin",
+			Extractor:     "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
 		}
 		r.References["cdn_frontdoor_rule_set_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/cdn/v1beta1.FrontdoorRuleSet",
-			Extractor: "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
+			TerraformName: "azurerm_cdn_frontdoor_rule_set",
+			Extractor:     "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
 		}
 		r.References["cdn_frontdoor_custom_domain_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/cdn/v1beta1.FrontdoorCustomDomain",
-			Extractor: "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
+			TerraformName: "azurerm_cdn_frontdoor_custom_domain",
+			Extractor:     "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_cdn_frontdoor_custom_domain_association", func(r *config.Resource) {
 		r.References["cdn_frontdoor_route_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/cdn/v1beta1.FrontdoorRoute",
-			Extractor: "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
+			TerraformName: "azurerm_cdn_frontdoor_route",
+			Extractor:     "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_cdn_frontdoor_firewall_policy", func(r *config.Resource) {

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -15,8 +15,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_linux_virtual_machine", func(r *config.Resource) {
 		r.References["network_interface_ids"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/network/v1beta1.NetworkInterface",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_interface",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"platform_fault_domain",
@@ -45,8 +45,8 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("azurerm_windows_virtual_machine", func(r *config.Resource) {
 		r.References["network_interface_ids"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/network/v1beta1.NetworkInterface",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_interface",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"platform_fault_domain",

--- a/config/consumption/config.go
+++ b/config/consumption/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_consumption_budget_subscription", func(r *config.Resource) {
 		r.References["notification.contact_groups"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/insights/v1beta1.MonitorActionGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_monitor_action_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/containerregistry/config.go
+++ b/config/containerregistry/config.go
@@ -21,19 +21,19 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_container_registry_token", func(r *config.Resource) {
 		r.References["scope_map_id"] = config.Reference{
-			Type:      "ScopeMap",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_container_registry_scope_map",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_container_connected_registry", func(r *config.Resource) {
 		r.References["container_registry_id"] = config.Reference{
-			Type:      "Registry",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_container_registry",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["sync_token_id"] = config.Reference{
-			Type:      "Token",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_container_registry_token",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.ExternalName.IdentifierFields = common.RemoveIndex(r.ExternalName.IdentifierFields, "container_registry_id")
 	})

--- a/config/containerservice/config.go
+++ b/config/containerservice/config.go
@@ -86,8 +86,8 @@ func Configure(p *config.Provider) {
 		r.Kind = "KubernetesClusterNodePool"
 		r.ShortGroup = "containerservice"
 		r.References["kubernetes_cluster_id"] = config.Reference{
-			Type:      "KubernetesCluster",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_kubernetes_cluster",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/cosmosdb/config.go
+++ b/config/cosmosdb/config.go
@@ -17,21 +17,21 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("azurerm_cosmosdb_sql_container", func(r *config.Resource) {
 		r.References["database_name"] = config.Reference{
-			Type: "SQLDatabase",
+			TerraformName: "azurerm_cosmosdb_sql_database",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_mongo_collection", func(r *config.Resource) {
 		r.References["database_name"] = config.Reference{
-			Type: "MongoDatabase",
+			TerraformName: "azurerm_cosmosdb_mongo_database",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_cassandra_table", func(r *config.Resource) {
 		delete(r.References, "cassandra_keyspace_id")
 		r.References["cassandra_keyspace_id"] = config.Reference{
-			Type:      "CassandraKeySpace",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_cosmosdb_cassandra_keyspace",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"analytical_storage_ttl"},
@@ -40,31 +40,31 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_gremlin_graph", func(r *config.Resource) {
 		r.References["database_name"] = config.Reference{
-			Type: "GremlinDatabase",
+			TerraformName: "azurerm_cosmosdb_gremlin_database",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_sql_function", func(r *config.Resource) {
 		r.References["container_id"] = config.Reference{
-			Type:      "SQLContainer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_cosmosdb_sql_container",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_sql_stored_procedure", func(r *config.Resource) {
 		r.References["database_name"] = config.Reference{
-			Type: "SQLDatabase",
+			TerraformName: "azurerm_cosmosdb_sql_database",
 		}
 		r.References["container_name"] = config.Reference{
-			Type: "SQLContainer",
+			TerraformName: "azurerm_cosmosdb_sql_container",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_sql_trigger", func(r *config.Resource) {
 		r.References = config.References{
 			"container_id": config.Reference{
-				Type:      "SQLContainer",
-				Extractor: rconfig.ExtractResourceIDFuncPath,
+				TerraformName: "azurerm_cosmosdb_sql_container",
+				Extractor:     rconfig.ExtractResourceIDFuncPath,
 			},
 		}
 	})

--- a/config/costmanagement/config.go
+++ b/config/costmanagement/config.go
@@ -12,8 +12,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_subscription_cost_management_export", func(r *config.Resource) {
 		r.References["subscription_id"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/azure/v1beta1.Subscription",
-			Extractor: "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
+			TerraformName: "azurerm_subscription",
+			Extractor:     "github.com/crossplane/upjet/pkg/resource.ExtractResourceID()",
 		}
 	})
 }

--- a/config/dataprotection/config.go
+++ b/config/dataprotection/config.go
@@ -14,21 +14,21 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_data_protection_backup_policy_blob_storage", func(r *config.Resource) {
 		r.References["vault_id"] = config.Reference{
-			Type:      "BackupVault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_protection_backup_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_data_protection_backup_policy_disk", func(r *config.Resource) {
 		r.References["vault_id"] = config.Reference{
-			Type:      "BackupVault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_protection_backup_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_data_protection_backup_policy_postgresql", func(r *config.Resource) {
 		r.References["vault_name"] = config.Reference{
-			Type: "BackupVault",
+			TerraformName: "azurerm_data_protection_backup_vault",
 		}
 	})
 }

--- a/config/datashare/config.go
+++ b/config/datashare/config.go
@@ -19,60 +19,60 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_data_share", func(r *config.Resource) {
 		r.Kind = "DataShare"
 		r.References["account_id"] = config.Reference{
-			Type:      "Account",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_share_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_data_share_dataset_blob_storage", func(r *config.Resource) {
 		r.References["data_share_id"] = config.Reference{
-			Type:      "DataShare",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_share",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["container_name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/storage/v1beta1.Container",
+			TerraformName: "azurerm_storage_container",
 		}
 		r.References["storage_account.name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/storage/v1beta1.Account",
+			TerraformName: "azurerm_storage_account",
 		}
 		r.References["storage_account.resource_group_name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/azure/v1beta1.ResourceGroup",
+			TerraformName: "azurerm_resource_group",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_data_share_dataset_data_lake_gen2", func(r *config.Resource) {
 		r.References["share_id"] = config.Reference{
-			Type:      "DataShare",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_share",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["storage_account_id"] = config.Reference{
-			Type:      rconfig.StorageAccountReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["file_system_name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/storage/v1beta1.DataLakeGen2FileSystem",
+			TerraformName: "azurerm_storage_data_lake_gen2_filesystem",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_data_share_dataset_kusto_cluster", func(r *config.Resource) {
 		r.References["share_id"] = config.Reference{
-			Type:      "DataShare",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_share",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["kusto_cluster_id"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/kusto/v1beta1.Cluster",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_kusto_cluster",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_data_share_dataset_kusto_database", func(r *config.Resource) {
 		r.References["share_id"] = config.Reference{
-			Type:      "DataShare",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_data_share",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["kusto_database_id"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/kusto/v1beta1.Database",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_kusto_database",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/dbformysql/config.go
+++ b/config/dbformysql/config.go
@@ -24,26 +24,26 @@ const (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_mysql_flexible_server", func(r *config.Resource) {
 		r.References["private_dns_zone_id"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/network/v1beta1.PrivateDNSZone",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_private_dns_zone",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mysql_flexible_database", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "FlexibleServer",
+			TerraformName: "azurerm_mysql_flexible_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mysql_flexible_server_configuration", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "FlexibleServer",
+			TerraformName: "azurerm_mysql_flexible_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mysql_flexible_server_firewall_rule", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "FlexibleServer",
+			TerraformName: "azurerm_mysql_flexible_server",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_mysql_server", func(r *config.Resource) {

--- a/config/devices/config.go
+++ b/config/devices/config.go
@@ -7,8 +7,6 @@ package devices
 import (
 	"github.com/crossplane/upjet/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/upbound/provider-azure/apis/rconfig"
 )
 
 // Configure configures iothub group
@@ -32,46 +30,46 @@ func Configure(p *config.Provider) {
 
 		r.Kind = "IOTHub"
 		r.References["endpoint.container_name"] = config.Reference{
-			Type: rconfig.ContainerReferencePath,
+			TerraformName: "azurerm_storage_container",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_iothub_consumer_group", func(r *config.Resource) {
 		r.References["iothub_name"] = config.Reference{
-			Type: "IOTHub",
+			TerraformName: "azurerm_iothub",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_iothub_dps_certificate", func(r *config.Resource) {
 		r.References["iot_dps_name"] = config.Reference{
-			Type: "IOTHubDPS",
+			TerraformName: "azurerm_iothub_dps",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_iothub_dps_shared_access_policy", func(r *config.Resource) {
 		r.References["iot_dps_name"] = config.Reference{
-			Type: "IOTHubDPS",
+			TerraformName: "azurerm_iothub_dps",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_iothub_shared_access_policy", func(r *config.Resource) {
 		r.References["iot_dps_name"] = config.Reference{
-			Type: "IOTHubDPS",
+			TerraformName: "azurerm_iothub_dps",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_iothub_endpoint_storage_container", func(r *config.Resource) {
 		r.References["container_name"] = config.Reference{
-			Type: rconfig.ContainerReferencePath,
+			TerraformName: "azurerm_storage_container",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_iothub_fallback_route", func(r *config.Resource) {
 		r.References["iothub_name"] = config.Reference{
-			Type: "IOTHub",
+			TerraformName: "azurerm_iothub",
 		}
 		r.References["endpoint_names"] = config.Reference{
-			Type: "IOTHubEndpointStorageContainer",
+			TerraformName: "azurerm_iothub_endpoint_storage_container",
 		}
 	})
 

--- a/config/eventhub/config.go
+++ b/config/eventhub/config.go
@@ -19,25 +19,25 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_eventhub", func(r *config.Resource) {
 		r.References["namespace_name"] = config.Reference{
-			Type: "EventHubNamespace",
+			TerraformName: "azurerm_eventhub_namespace",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_eventhub_consumer_group", func(r *config.Resource) {
 		r.References["namespace_name"] = config.Reference{
-			Type: "EventHubNamespace",
+			TerraformName: "azurerm_eventhub_namespace",
 		}
 		r.References["eventhub_name"] = config.Reference{
-			Type: "EventHub",
+			TerraformName: "azurerm_eventhub",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_eventhub_authorization_rule", func(r *config.Resource) {
 		r.References["namespace_name"] = config.Reference{
-			Type: "EventHubNamespace",
+			TerraformName: "azurerm_eventhub_namespace",
 		}
 		r.References["eventhub_name"] = config.Reference{
-			Type: "EventHub",
+			TerraformName: "azurerm_eventhub",
 		}
 	})
 }

--- a/config/healthcareapis/config.go
+++ b/config/healthcareapis/config.go
@@ -14,28 +14,28 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_healthcare_medtech_service", func(r *config.Resource) {
 		r.References["workspace_id"] = config.Reference{
-			Type:      "HealthcareWorkspace",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_healthcare_workspace",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["eventhub_namespace_name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/eventhub/v1beta1.EventHubNamespace",
+			TerraformName: "azurerm_eventhub_namespace",
 		}
 		r.References["eventhub_name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/eventhub/v1beta1.EventHub",
+			TerraformName: "azurerm_eventhub",
 		}
 		r.References["eventhub_consumer_group_name"] = config.Reference{
-			Type: rconfig.APISPackagePath + "/eventhub/v1beta1.ConsumerGroup",
+			TerraformName: "azurerm_eventhub_consumer_group",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_healthcare_medtech_service_fhir_destination", func(r *config.Resource) {
 		r.References["medtech_service_id"] = config.Reference{
-			Type:      "HealthcareMedtechService",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_healthcare_medtech_service",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["destination_fhir_service_id"] = config.Reference{
-			Type:      "HealthcareFHIRService",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_healthcare_fhir_service",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/insights/config.go
+++ b/config/insights/config.go
@@ -14,40 +14,40 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_monitor_metric_alert", func(r *config.Resource) {
 		r.References["scopes"] = config.Reference{
-			Type:      rconfig.StorageAccountReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["action.action_group_id"] = config.Reference{
-			Type:      "MonitorActionGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_monitor_action_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_monitor_private_link_scoped_service", func(r *config.Resource) {
 		r.References["scope_name"] = config.Reference{
-			Type: "MonitorPrivateLinkScope",
+			TerraformName: "azurerm_monitor_private_link_scope",
 		}
 		r.References["linked_resource_id"] = config.Reference{
-			Type:      "ApplicationInsights",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_application_insights",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("azurerm_monitor_activity_log_alert", func(r *config.Resource) {
 		r.References["scopes"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/azure/v1beta1.ResourceGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_resource_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("azurerm_monitor_scheduled_query_rules_alert", func(r *config.Resource) {
 		r.References["action.action_group"] = config.Reference{
-			Type:      "MonitorActionGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_monitor_action_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("azurerm_monitor_scheduled_query_rules_alert_v2", func(r *config.Resource) {
 		r.References["scopes"] = config.Reference{
-			Type:      "ApplicationInsights",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_application_insights",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 	p.AddResourceConfigurator("azurerm_monitor_diagnostic_setting", func(r *config.Resource) {

--- a/config/keyvault/config.go
+++ b/config/keyvault/config.go
@@ -19,15 +19,15 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_key_vault_secret", func(r *config.Resource) {
 		r.References["key_vault_id"] = config.Reference{
-			Type:      "Vault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_key_vault_key", func(r *config.Resource) {
 		r.References["key_vault_id"] = config.Reference{
-			Type:      "Vault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"rotation_policy"},
@@ -36,40 +36,40 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_key_vault_certificate", func(r *config.Resource) {
 		r.References["key_vault_id"] = config.Reference{
-			Type:      "Vault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_key_vault_certificate_issuer", func(r *config.Resource) {
 		r.References["key_vault_id"] = config.Reference{
-			Type:      "Vault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_key_vault_managed_storage_account", func(r *config.Resource) {
 		r.References["key_vault_id"] = config.Reference{
-			Type:      "Vault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["storage_account_id"] = config.Reference{
-			Type:      rconfig.StorageAccountReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_key_vault_access_policy", func(r *config.Resource) {
 		r.References["key_vault_id"] = config.Reference{
-			Type:      "Vault",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_key_vault_managed_storage_account_sas_token_definition", func(r *config.Resource) {
 		r.References["managed_storage_account_id"] = config.Reference{
-			Type:      "ManagedStorageAccount",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault_managed_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/kusto/config.go
+++ b/config/kusto/config.go
@@ -12,7 +12,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_kusto_database", func(r *config.Resource) {
 		r.References["cluster_name"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "azurerm_kusto_cluster",
 		}
 	})
 }

--- a/config/logic/config.go
+++ b/config/logic/config.go
@@ -6,8 +6,6 @@ package logic
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
-
-	"github.com/upbound/provider-azure/apis/rconfig"
 )
 
 // Configure configures logic group
@@ -16,8 +14,8 @@ func Configure(p *config.Provider) {
 		r.Kind = "IntegrationServiceEnvironment"
 
 		r.References["virtual_network_subnet_ids"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/network/v1beta1.Subnet",
-			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("id",true)`,
+			TerraformName: "azurerm_subnet",
+			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("id",true)`,
 		}
 	})
 }

--- a/config/management/config.go
+++ b/config/management/config.go
@@ -18,12 +18,12 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_management_group_subscription_association", func(r *config.Resource) {
 		r.Kind = "ManagementGroupSubscriptionAssociation"
 		r.References["management_group_id"] = config.Reference{
-			Type:      "ManagementGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_management_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["subscription_id"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/azure/v1beta1.Subscription",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subscription",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/media/config.go
+++ b/config/media/config.go
@@ -14,63 +14,63 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_media_services_account", func(r *config.Resource) {
 		r.References["storage_account.id"] = config.Reference{
-			Type:      rconfig.StorageAccountReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_asset", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_live_event", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_live_event_output", func(r *config.Resource) {
 		r.References["live_event_id"] = config.Reference{
-			Type:      "LiveEvent",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_media_live_event",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["asset_name"] = config.Reference{
-			Type: "Asset",
+			TerraformName: "azurerm_media_asset",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_streaming_endpoint", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_streaming_locator", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 		r.References["asset_name"] = config.Reference{
-			Type: "Asset",
+			TerraformName: "azurerm_media_asset",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_streaming_policy", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_transform", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_media_services_account_filter", func(r *config.Resource) {
 		r.References["media_services_account_name"] = config.Reference{
-			Type: "ServicesAccount",
+			TerraformName: "azurerm_media_services_account",
 		}
 	})
 }

--- a/config/netapp/config.go
+++ b/config/netapp/config.go
@@ -14,46 +14,46 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_netapp_pool", func(r *config.Resource) {
 		r.References["account_name"] = config.Reference{
-			Type: "Account",
+			TerraformName: "azurerm_netapp_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_netapp_snapshot_policy", func(r *config.Resource) {
 		r.References["account_name"] = config.Reference{
-			Type: "Account",
+			TerraformName: "azurerm_netapp_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_netapp_snapshot", func(r *config.Resource) {
 		r.References["account_name"] = config.Reference{
-			Type: "Account",
+			TerraformName: "azurerm_netapp_account",
 		}
 		r.References["pool_name"] = config.Reference{
-			Type: "Pool",
+			TerraformName: "azurerm_netapp_pool",
 		}
 		r.References["volume_name"] = config.Reference{
-			Type: "Volume",
+			TerraformName: "azurerm_netapp_volume",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_netapp_volume", func(r *config.Resource) {
 		r.References["account_name"] = config.Reference{
-			Type: "Account",
+			TerraformName: "azurerm_netapp_account",
 		}
 		r.References["pool_name"] = config.Reference{
-			Type: "Pool",
+			TerraformName: "azurerm_netapp_pool",
 		}
 		r.References["data_protection_snapshot_policy.snapshot_policy_id"] = config.Reference{
-			Type:      "SnapshotPolicy",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_netapp_snapshot_policy",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["data_protection_replication.remote_volume_resource_id"] = config.Reference{
-			Type:      "Volume",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_netapp_volume",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["create_from_snapshot_resource_id"] = config.Reference{
-			Type:      "Snapshot",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_netapp_snapshot",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		delete(r.References, "data_protection_replication.remote_volume_location")
 	})

--- a/config/network/config.go
+++ b/config/network/config.go
@@ -30,94 +30,94 @@ func Configure(p *config.Provider) {
 		r.Kind = "LoadBalancer"
 
 		r.References["frontend_ip_configuration.public_ip_address_id"] = config.Reference{
-			Type:      "PublicIP",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_public_ip",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_backend_address_pool", func(r *config.Resource) {
 		r.Kind = "LoadBalancerBackendAddressPool"
 		r.References["loadbalancer_id"] = config.Reference{
-			Type:      "LoadBalancer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_backend_address_pool_address", func(r *config.Resource) {
 		r.Kind = "LoadBalancerBackendAddressPoolAddress"
 		r.References["backend_address_pool_id"] = config.Reference{
-			Type:      "LoadBalancerBackendAddressPool",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb_backend_address_pool",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["virtual_network_id"] = config.Reference{
-			Type:      "VirtualNetwork",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_network",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_nat_pool", func(r *config.Resource) {
 		r.Kind = "LoadBalancerNatPool"
 		r.References["loadbalancer_id"] = config.Reference{
-			Type:      "LoadBalancer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_nat_rule", func(r *config.Resource) {
 		r.Kind = "LoadBalancerNatRule"
 		r.References["loadbalancer_id"] = config.Reference{
-			Type:      "LoadBalancer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_outbound_rule", func(r *config.Resource) {
 		r.Kind = "LoadBalancerOutboundRule"
 		r.References["backend_address_pool_id"] = config.Reference{
-			Type:      "LoadBalancerBackendAddressPool",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb_backend_address_pool",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["loadbalancer_id"] = config.Reference{
-			Type:      "LoadBalancer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_probe", func(r *config.Resource) {
 		r.Kind = "LoadBalancerProbe"
 		r.References["loadbalancer_id"] = config.Reference{
-			Type:      "LoadBalancer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_lb_rule", func(r *config.Resource) {
 		r.Kind = "LoadBalancerRule"
 		r.References["loadbalancer_id"] = config.Reference{
-			Type:      "LoadBalancer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_nat_gateway_public_ip_association", func(r *config.Resource) {
 		r.References["nat_gateway_id"] = config.Reference{
-			Type:      "NATGateway",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_nat_gateway",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["public_ip_address_id"] = config.Reference{
-			Type:      "PublicIP",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_public_ip",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_nat_gateway_public_ip_prefix_association", func(r *config.Resource) {
 		r.References["nat_gateway_id"] = config.Reference{
-			Type:      "NATGateway",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_nat_gateway",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["public_ip_prefix_id"] = config.Reference{
-			Type:      "PublicIPPrefix",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_public_ip_prefix",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -127,15 +127,15 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_network_watcher_flow_log", func(r *config.Resource) {
 		r.References["network_watcher_name"] = config.Reference{
-			Type: "Watcher",
+			TerraformName: "azurerm_network_watcher",
 		}
 		r.References["network_security_group_id"] = config.Reference{
-			Type:      "SecurityGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_security_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["storage_account_id"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/storage/v1beta1.Account",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		delete(r.References, "traffic_analytics.workspace_region")
 	})
@@ -143,8 +143,8 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_network_connection_monitor", func(r *config.Resource) {
 		r.Kind = "ConnectionMonitor"
 		r.References["network_watcher_id"] = config.Reference{
-			Type:      "Watcher",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_watcher",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -154,55 +154,55 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_network_security_rule", func(r *config.Resource) {
 		r.References["network_security_group_name"] = config.Reference{
-			Type: "SecurityGroup",
+			TerraformName: "azurerm_network_security_group",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_network_interface_application_security_group_association", func(r *config.Resource) {
 		r.Kind = "NetworkInterfaceApplicationSecurityGroupAssociation"
 		r.References["network_interface_id"] = config.Reference{
-			Type:      "NetworkInterface",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_interface",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["application_security_group_id"] = config.Reference{
-			Type:      "ApplicationSecurityGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_application_security_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_network_interface_backend_address_pool_association", func(r *config.Resource) {
 		r.Kind = "NetworkInterfaceBackendAddressPoolAssociation"
 		r.References["network_interface_id"] = config.Reference{
-			Type:      "NetworkInterface",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_interface",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["backend_address_pool_id"] = config.Reference{
-			Type:      "LoadBalancerBackendAddressPool",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb_backend_address_pool",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_network_interface_nat_rule_association", func(r *config.Resource) {
 		r.Kind = "NetworkInterfaceNatRuleAssociation"
 		r.References["network_interface_id"] = config.Reference{
-			Type:      "NetworkInterface",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_interface",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["nat_rule_id"] = config.Reference{
-			Type:      "LoadBalancerNatRule",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_lb_nat_rule",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_network_interface_security_group_association", func(r *config.Resource) {
 		r.Kind = "NetworkInterfaceSecurityGroupAssociation"
 		r.References["network_interface_id"] = config.Reference{
-			Type:      "NetworkInterface",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_interface",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["network_security_group_id"] = config.Reference{
-			Type:      "SecurityGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_security_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -217,265 +217,265 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_virtual_network_gateway", func(r *config.Resource) {
 		r.Kind = "VirtualNetworkGateway"
 		r.References["ip_configuration.subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_virtual_network_peering", func(r *config.Resource) {
 		r.Kind = "VirtualNetworkPeering"
 		r.References["virtual_network_name"] = config.Reference{
-			Type: "VirtualNetwork",
+			TerraformName: "azurerm_virtual_network",
 		}
 		r.References["remote_virtual_network_id"] = config.Reference{
-			Type:      "VirtualNetwork",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_network",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_network_profile", func(r *config.Resource) {
 		r.References["container_network_interface.ip_configuration.subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_a_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_aaaa_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_cname_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_mx_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_ptr_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_srv_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_txt_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_dns_zone_virtual_network_link", func(r *config.Resource) {
 		r.References["private_dns_zone_name"] = config.Reference{
-			Type: "PrivateDNSZone",
+			TerraformName: "azurerm_private_dns_zone",
 		}
 		r.References["virtual_network_id"] = config.Reference{
-			Type:      "VirtualNetwork",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_network",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_a_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_aaaa_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_caa_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_cname_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_mx_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_ns_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_ptr_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_srv_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_dns_txt_record", func(r *config.Resource) {
 		r.References["zone_name"] = config.Reference{
-			Type: "DNSZone",
+			TerraformName: "azurerm_dns_zone",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_link_service", func(r *config.Resource) {
 		r.References["nat_ip_configuration.subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_private_endpoint", func(r *config.Resource) {
 		r.References["private_dns_zone_group.private_dns_zone_ids"] = config.Reference{
-			Type:      "PrivateDNSZone",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_private_dns_zone",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		delete(r.References, "private_service_connection.private_connection_resource_id")
 	})
 
 	p.AddResourceConfigurator("azurerm_network_packet_capture", func(r *config.Resource) {
 		r.References["network_watcher_name"] = config.Reference{
-			Type: "Watcher",
+			TerraformName: "azurerm_network_watcher",
 		}
 		r.References["storage_location.storage_account_id"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/storage/v1beta1.Account",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_point_to_site_vpn_gateway", func(r *config.Resource) {
 		r.References["virtual_hub_id"] = config.Reference{
-			Type:      "VirtualHub",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_hub",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["vpn_server_configuration_id"] = config.Reference{
-			Type:      "VPNServerConfiguration",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_vpn_server_configuration",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_express_route_circuit_authorization", func(r *config.Resource) {
 		r.References["express_route_circuit_name"] = config.Reference{
-			Type: "ExpressRouteCircuit",
+			TerraformName: "azurerm_express_route_circuit",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_express_route_circuit_peering", func(r *config.Resource) {
 		r.References["express_route_circuit_name"] = config.Reference{
-			Type: "ExpressRouteCircuit",
+			TerraformName: "azurerm_express_route_circuit",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_express_route_circuit_connection", func(r *config.Resource) {
 		r.References["peering_id"] = config.Reference{
-			Type:      "ExpressRouteCircuitPeering",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_express_route_circuit_peering",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["peer_peering_id"] = config.Reference{
-			Type:      "ExpressRouteCircuitPeering",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_express_route_circuit_peering",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_express_route_gateway", func(r *config.Resource) {
 		r.References["virtual_hub_id"] = config.Reference{
-			Type:      "VirtualHub",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_hub",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_express_route_connection", func(r *config.Resource) {
 		r.References["express_route_gateway_id"] = config.Reference{
-			Type:      "ExpressRouteGateway",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_express_route_gateway",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["express_route_circuit_peering_id"] = config.Reference{
-			Type:      "ExpressRouteCircuitPeering",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_express_route_circuit_peering",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_firewall", func(r *config.Resource) {
 		r.References["ip_configuration.subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["ip_configuration.public_ip_address_id"] = config.Reference{
-			Type:      "PublicIP",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_public_ip",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_firewall_application_rule_collection", func(r *config.Resource) {
 		r.References["azure_firewall_name"] = config.Reference{
-			Type: "Firewall",
+			TerraformName: "azurerm_firewall",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_firewall_nat_rule_collection", func(r *config.Resource) {
 		r.References["azure_firewall_name"] = config.Reference{
-			Type: "Firewall",
+			TerraformName: "azurerm_firewall",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_firewall_network_rule_collection", func(r *config.Resource) {
 		r.References["azure_firewall_name"] = config.Reference{
-			Type: "Firewall",
+			TerraformName: "azurerm_firewall",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_firewall_policy_rule_collection_group", func(r *config.Resource) {
 		r.References["firewall_policy_id"] = config.Reference{
-			Type:      "FirewallPolicy",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_firewall_policy",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_frontdoor_custom_https_configuration", func(r *config.Resource) {
 		r.References["custom_https_configuration.azure_key_vault_certificate_vault_id"] = config.Reference{
-			Type:      rconfig.VaultKeyReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault_key",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_frontdoor_rules_engine", func(r *config.Resource) {
 		r.References["frontdoor_name"] = config.Reference{
-			Type: "FrontDoor",
+			TerraformName: "azurerm_frontdoor",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_application_gateway", func(r *config.Resource) {
 		r.References["frontend_ip_configuration.public_ip_address_id"] = config.Reference{
-			Type:      "PublicIP",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_public_ip",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -500,12 +500,12 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_virtual_network_gateway_connection", func(r *config.Resource) {
 		r.Kind = "VirtualNetworkGatewayConnection"
 		r.References["virtual_network_gateway_id"] = config.Reference{
-			Type:      "VirtualNetworkGateway",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_network_gateway",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["peer_virtual_network_gateway_id"] = config.Reference{
-			Type:      "VirtualNetworkGateway",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_network_gateway",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -524,8 +524,8 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_virtual_hub", func(r *config.Resource) {
 		r.References["virtual_wan_id"] = config.Reference{
-			Type:      "VirtualWAN",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_wan",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.UseAsync = true
 	})
@@ -540,27 +540,27 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"address_prefix"},
 		}
 		r.References["virtual_network_name"] = config.Reference{
-			Type: "VirtualNetwork",
+			TerraformName: "azurerm_virtual_network",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_subnet_nat_gateway_association", func(r *config.Resource) {
 		r.Kind = "SubnetNATGatewayAssociation"
 		r.References["subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_subnet_network_security_group_association", func(r *config.Resource) {
 		r.Kind = "SubnetNetworkSecurityGroupAssociation"
 		r.References["subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["network_security_group_id"] = config.Reference{
-			Type:      "SecurityGroup",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_network_security_group",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -577,12 +577,12 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_subnet_route_table_association", func(r *config.Resource) {
 		r.Kind = "SubnetRouteTableAssociation"
 		r.References["subnet_id"] = config.Reference{
-			Type:      "Subnet",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_subnet",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["route_table_id"] = config.Reference{
-			Type:      "RouteTable",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_route_table",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -595,8 +595,8 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_network_manager_static_member", func(r *config.Resource) {
 		r.References["target_virtual_network_id"] = config.Reference{
-			Type:      "VirtualNetwork",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_virtual_network",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 

--- a/config/operationalinsights/config.go
+++ b/config/operationalinsights/config.go
@@ -18,8 +18,8 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_log_analytics_linked_storage_account", func(r *config.Resource) {
 		r.References["storage_account_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/storage/v1beta1.Account",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/postgresql/config.go
+++ b/config/postgresql/config.go
@@ -40,46 +40,46 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_postgresql_flexible_server_configuration", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "FlexibleServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_postgresql_flexible_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_database", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "Server",
+			TerraformName: "azurerm_postgresql_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_active_directory_administrator", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "Server",
+			TerraformName: "azurerm_postgresql_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_flexible_server_active_directory_administrator", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "FlexibleServer",
+			TerraformName: "azurerm_postgresql_flexible_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_flexible_server_database", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "FlexibleServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_postgresql_flexible_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_firewall_rule", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "Server",
+			TerraformName: "azurerm_postgresql_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_flexible_server_firewall_rule", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "FlexibleServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_postgresql_flexible_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
@@ -116,24 +116,24 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_postgresql_virtual_network_rule", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "Server",
+			TerraformName: "azurerm_postgresql_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_server_key", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "Server",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_postgresql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["key_vault_key_id"] = config.Reference{
-			Type:      rconfig.VaultKeyReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault_key",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_postgresql_configuration", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "Server",
+			TerraformName: "azurerm_postgresql_server",
 		}
 	})
 }

--- a/config/resources/config.go
+++ b/config/resources/config.go
@@ -14,15 +14,15 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_resource_deployment_script_azure_cli", func(r *config.Resource) {
 		r.References["identity.identity_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/managedidentity/v1beta1.UserAssignedIdentity",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_user_assigned_identity",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.Path = "resourcedeploymentscriptazureclicli"
 	})
 	p.AddResourceConfigurator("azurerm_resource_deployment_script_azure_power_shell", func(r *config.Resource) {
 		r.References["identity.identity_ids"] = config.Reference{
-			Type:      "github.com/upbound/provider-azure/apis/managedidentity/v1beta1.UserAssignedIdentity",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_user_assigned_identity",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/config/security/config.go
+++ b/config/security/config.go
@@ -6,8 +6,6 @@ package security
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
-
-	"github.com/upbound/provider-azure/apis/rconfig"
 )
 
 // Configure configures security group
@@ -25,8 +23,8 @@ func Configure(p *config.Provider) {
 		r.Kind = "IOTSecuritySolution"
 
 		r.References["iothub_ids"] = config.Reference{
-			Type:      rconfig.APISPackagePath + "/devices/v1beta1.IOTHub",
-			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("id",true)`,
+			TerraformName: "azurerm_iothub",
+			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("id",true)`,
 		}
 	})
 }

--- a/config/sql/config.go
+++ b/config/sql/config.go
@@ -51,80 +51,80 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_mssql_server_transparent_data_encryption", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["key_vault_key_id"] = config.Reference{
-			Type:      rconfig.VaultKeyReferencePath,
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_key_vault_key",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_virtual_network_rule", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_managed_instance", func(r *config.Resource) {
 		r.References["dns_zone_partner_id"] = config.Reference{
-			Type:      "MSSQLManagedInstance",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_managed_instance",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_managed_database", func(r *config.Resource) {
 		r.References["managed_instance_id"] = config.Reference{
-			Type:      "MSSQLManagedInstance",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_managed_instance",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_managed_instance_active_directory_administrator", func(r *config.Resource) {
 		r.References["managed_instance_id"] = config.Reference{
-			Type:      "MSSQLManagedInstance",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_managed_instance",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_failover_group", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["partner_server.id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["databases"] = config.Reference{
-			Type:      "MSSQLDatabase",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_database",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_managed_instance_failover_group", func(r *config.Resource) {
 		r.References["managed_instance_id"] = config.Reference{
-			Type:      "MSSQLManagedInstance",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_managed_instance",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.References["partner_managed_instance_id"] = config.Reference{
-			Type:      "MSSQLManagedInstance",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_managed_instance",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_managed_instance_vulnerability_assessment", func(r *config.Resource) {
 		r.References["managed_instance_id"] = config.Reference{
-			Type:      "MSSQLManagedInstance",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_managed_instance",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_database", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"maintenance_configuration_name", "elastic_pool_id"},
@@ -133,21 +133,21 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("azurerm_mssql_outbound_firewall_rule", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_server_dns_alias", func(r *config.Resource) {
 		r.References["mssql_server_id"] = config.Reference{
-			Type:      "MSSQLServer",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_mssql_server",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_server_security_alert_policy", func(r *config.Resource) {
 		r.References["server_name"] = config.Reference{
-			Type: "MSSQLServer",
+			TerraformName: "azurerm_mssql_server",
 		}
 	})
 
@@ -156,13 +156,13 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"max_size_bytes"},
 		}
 		r.References["server_name"] = config.Reference{
-			Type: "MSSQLServer",
+			TerraformName: "azurerm_mssql_server",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_mssql_database_vulnerability_assessment_rule_baseline", func(r *config.Resource) {
 		r.References["database_name"] = config.Reference{
-			Type: "MSSQLDatabase",
+			TerraformName: "azurerm_mssql_database",
 		}
 	})
 }

--- a/config/storage/config.go
+++ b/config/storage/config.go
@@ -15,23 +15,23 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_storage_blob", func(r *config.Resource) {
 		r.References["storage_account_name"] = config.Reference{
-			Type: "Account",
+			TerraformName: "azurerm_storage_account",
 		}
 		r.References["storage_container_name"] = config.Reference{
-			Type: "Container",
+			TerraformName: "azurerm_storage_container",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_storage_container", func(r *config.Resource) {
 		r.References["storage_account_name"] = config.Reference{
-			Type: "Account",
+			TerraformName: "azurerm_storage_account",
 		}
 	})
 
 	p.AddResourceConfigurator("azurerm_storage_data_lake_gen2_filesystem", func(r *config.Resource) {
 		r.References["storage_account_id"] = config.Reference{
-			Type:      "Account",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_storage_account",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 

--- a/config/streamanalytics/config.go
+++ b/config/streamanalytics/config.go
@@ -14,69 +14,69 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_synapse", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_function_javascript_uda", func(r *config.Resource) {
 		r.References["stream_analytics_job_id"] = config.Reference{
-			Type:      "Job",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_stream_analytics_job",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 		r.Path = "functionjavascriptudas"
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_blob", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_mssql", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_mssql", func(r *config.Resource) {
 		r.References["server"] = config.Reference{
-			Type: "github.com/upbound/provider-azure/apis/sql/v1beta1.MSSQLServer",
+			TerraformName: "azurerm_mssql_server",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_mssql", func(r *config.Resource) {
 		r.References["table"] = config.Reference{
-			Type: "github.com/upbound/provider-azure/apis/storage/v1beta1.Table",
+			TerraformName: "azurerm_storage_table",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_reference_input_blob", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_stream_input_blob", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_stream_input_eventhub", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_stream_input_iothub", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_stream_input_iothub", func(r *config.Resource) {
 		r.References["eventhub_consumer_group_name"] = config.Reference{
-			Type: "github.com/upbound/provider-azure/apis/eventhub/v1beta1.ConsumerGroup",
+			TerraformName: "azurerm_eventhub_consumer_group",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_servicebus_queue", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_servicebus_topic", func(r *config.Resource) {
 		r.References["stream_analytics_job_name"] = config.Reference{
-			Type: "Job",
+			TerraformName: "azurerm_stream_analytics_job",
 		}
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_stream_input_eventhub_v2", func(r *config.Resource) {
@@ -87,8 +87,8 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("azurerm_stream_analytics_output_powerbi", func(r *config.Resource) {
 		r.References["stream_analytics_job_id"] = config.Reference{
-			Type:      "Job",
-			Extractor: rconfig.ExtractResourceIDFuncPath,
+			TerraformName: "azurerm_stream_analytics_job",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
 	})
 }

--- a/package/crds/apimanagement.azure.upbound.io_apioperations.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_apioperations.yaml
@@ -78,7 +78,8 @@ spec:
                       API exists. Changing this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +113,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -157,7 +159,7 @@ spec:
                       a new resource to be created.
                     type: string
                   apiNameRef:
-                    description: Reference to a API to populate apiName.
+                    description: Reference to a API in apimanagement to populate apiName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -191,7 +193,7 @@ spec:
                     - name
                     type: object
                   apiNameSelector:
-                    description: Selector for a API to populate apiName.
+                    description: Selector for a API in apimanagement to populate apiName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_apipolicies.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_apipolicies.yaml
@@ -78,7 +78,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +113,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -156,7 +158,7 @@ spec:
                       Service. Changing this forces a new resource to be created.
                     type: string
                   apiNameRef:
-                    description: Reference to a API to populate apiName.
+                    description: Reference to a API in apimanagement to populate apiName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -190,7 +192,7 @@ spec:
                     - name
                     type: object
                   apiNameSelector:
-                    description: Selector for a API to populate apiName.
+                    description: Selector for a API in apimanagement to populate apiName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_apischemas.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_apischemas.yaml
@@ -78,7 +78,8 @@ spec:
                       API exists. Changing this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +113,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -157,7 +159,7 @@ spec:
                       a new resource to be created.
                     type: string
                   apiNameRef:
-                    description: Reference to a API to populate apiName.
+                    description: Reference to a API in apimanagement to populate apiName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -191,7 +193,7 @@ spec:
                     - name
                     type: object
                   apiNameSelector:
-                    description: Selector for a API to populate apiName.
+                    description: Selector for a API in apimanagement to populate apiName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_authorizationservers.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_authorizationservers.yaml
@@ -79,7 +79,8 @@ spec:
                       a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +114,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_gatewayapis.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_gatewayapis.yaml
@@ -79,7 +79,7 @@ spec:
                       Gateway API to be created.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apimanagement to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apimanagement to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -157,7 +157,8 @@ spec:
                       this forces a new API Management Gateway API to be created.
                     type: string
                   gatewayIdRef:
-                    description: Reference to a Gateway to populate gatewayId.
+                    description: Reference to a Gateway in apimanagement to populate
+                      gatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -191,7 +192,8 @@ spec:
                     - name
                     type: object
                   gatewayIdSelector:
-                    description: Selector for a Gateway to populate gatewayId.
+                    description: Selector for a Gateway in apimanagement to populate
+                      gatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -250,7 +252,7 @@ spec:
                       Gateway API to be created.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apimanagement to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -284,7 +286,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apimanagement to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -328,7 +330,8 @@ spec:
                       this forces a new API Management Gateway API to be created.
                     type: string
                   gatewayIdRef:
-                    description: Reference to a Gateway to populate gatewayId.
+                    description: Reference to a Gateway in apimanagement to populate
+                      gatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -362,7 +365,8 @@ spec:
                     - name
                     type: object
                   gatewayIdSelector:
-                    description: Selector for a Gateway to populate gatewayId.
+                    description: Selector for a Gateway in apimanagement to populate
+                      gatewayId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_productapis.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_productapis.yaml
@@ -78,7 +78,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +113,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -157,7 +159,7 @@ spec:
                       created.
                     type: string
                   apiNameRef:
-                    description: Reference to a API to populate apiName.
+                    description: Reference to a API in apimanagement to populate apiName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -191,7 +193,7 @@ spec:
                     - name
                     type: object
                   apiNameSelector:
-                    description: Selector for a API to populate apiName.
+                    description: Selector for a API in apimanagement to populate apiName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -236,7 +238,8 @@ spec:
                       created.
                     type: string
                   productIdRef:
-                    description: Reference to a Product to populate productId.
+                    description: Reference to a Product in apimanagement to populate
+                      productId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -270,7 +273,8 @@ spec:
                     - name
                     type: object
                   productIdSelector:
-                    description: Selector for a Product to populate productId.
+                    description: Selector for a Product in apimanagement to populate
+                      productId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_productpolicies.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_productpolicies.yaml
@@ -78,7 +78,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +113,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -157,7 +159,8 @@ spec:
                       created.
                     type: string
                   productIdRef:
-                    description: Reference to a Product to populate productId.
+                    description: Reference to a Product in apimanagement to populate
+                      productId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -191,7 +194,8 @@ spec:
                     - name
                     type: object
                   productIdSelector:
-                    description: Selector for a Product to populate productId.
+                    description: Selector for a Product in apimanagement to populate
+                      productId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_subscriptions.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_subscriptions.yaml
@@ -87,7 +87,8 @@ spec:
                       to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a Management to populate apiManagementName.
+                    description: Reference to a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +122,8 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a Management to populate apiManagementName.
+                    description: Selector for a Management in apimanagement to populate
+                      apiManagementName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -183,7 +185,8 @@ spec:
                       created.
                     type: string
                   productIdRef:
-                    description: Reference to a Product to populate productId.
+                    description: Reference to a Product in apimanagement to populate
+                      productId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -217,7 +220,8 @@ spec:
                     - name
                     type: object
                   productIdSelector:
-                    description: Selector for a Product to populate productId.
+                    description: Selector for a Product in apimanagement to populate
+                      productId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -368,7 +372,8 @@ spec:
                       Subscription. Changing this forces a new resource to be created.
                     type: string
                   userIdRef:
-                    description: Reference to a User to populate userId.
+                    description: Reference to a User in apimanagement to populate
+                      userId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -402,7 +407,8 @@ spec:
                     - name
                     type: object
                   userIdSelector:
-                    description: Selector for a User to populate userId.
+                    description: Selector for a User in apimanagement to populate
+                      userId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -469,7 +475,8 @@ spec:
                       created.
                     type: string
                   productIdRef:
-                    description: Reference to a Product to populate productId.
+                    description: Reference to a Product in apimanagement to populate
+                      productId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -503,7 +510,8 @@ spec:
                     - name
                     type: object
                   productIdSelector:
-                    description: Selector for a Product to populate productId.
+                    description: Selector for a Product in apimanagement to populate
+                      productId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -557,7 +565,8 @@ spec:
                       Subscription. Changing this forces a new resource to be created.
                     type: string
                   userIdRef:
-                    description: Reference to a User to populate userId.
+                    description: Reference to a User in apimanagement to populate
+                      userId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -591,7 +600,8 @@ spec:
                     - name
                     type: object
                   userIdSelector:
-                    description: Selector for a User to populate userId.
+                    description: Selector for a User in apimanagement to populate
+                      userId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cache.azure.upbound.io_redislinkedservers.yaml
+++ b/package/crds/cache.azure.upbound.io_redislinkedservers.yaml
@@ -78,7 +78,7 @@ spec:
                       a new Redis to be created.
                     type: string
                   linkedRedisCacheIdRef:
-                    description: Reference to a RedisCache to populate linkedRedisCacheId.
+                    description: Reference to a RedisCache in cache to populate linkedRedisCacheId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   linkedRedisCacheIdSelector:
-                    description: Selector for a RedisCache to populate linkedRedisCacheId.
+                    description: Selector for a RedisCache in cache to populate linkedRedisCacheId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -245,7 +245,7 @@ spec:
                       forces a new Redis to be created. (eg The primary role)
                     type: string
                   targetRedisCacheNameRef:
-                    description: Reference to a RedisCache to populate targetRedisCacheName.
+                    description: Reference to a RedisCache in cache to populate targetRedisCacheName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -279,7 +279,7 @@ spec:
                     - name
                     type: object
                   targetRedisCacheNameSelector:
-                    description: Selector for a RedisCache to populate targetRedisCacheName.
+                    description: Selector for a RedisCache in cache to populate targetRedisCacheName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -337,7 +337,7 @@ spec:
                       a new Redis to be created.
                     type: string
                   linkedRedisCacheIdRef:
-                    description: Reference to a RedisCache to populate linkedRedisCacheId.
+                    description: Reference to a RedisCache in cache to populate linkedRedisCacheId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -371,7 +371,7 @@ spec:
                     - name
                     type: object
                   linkedRedisCacheIdSelector:
-                    description: Selector for a RedisCache to populate linkedRedisCacheId.
+                    description: Selector for a RedisCache in cache to populate linkedRedisCacheId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/containerregistry.azure.upbound.io_containerconnectedregistries.yaml
+++ b/package/crds/containerregistry.azure.upbound.io_containerconnectedregistries.yaml
@@ -90,7 +90,8 @@ spec:
                       Connected Registry to be created.
                     type: string
                   containerRegistryIdRef:
-                    description: Reference to a Registry to populate containerRegistryId.
+                    description: Reference to a Registry in containerregistry to populate
+                      containerRegistryId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -124,7 +125,8 @@ spec:
                     - name
                     type: object
                   containerRegistryIdSelector:
-                    description: Selector for a Registry to populate containerRegistryId.
+                    description: Selector for a Registry in containerregistry to populate
+                      containerRegistryId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -217,7 +219,8 @@ spec:
                       a new Container Connected Registry to be created.
                     type: string
                   syncTokenIdRef:
-                    description: Reference to a Token to populate syncTokenId.
+                    description: Reference to a Token in containerregistry to populate
+                      syncTokenId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -251,7 +254,8 @@ spec:
                     - name
                     type: object
                   syncTokenIdSelector:
-                    description: Selector for a Token to populate syncTokenId.
+                    description: Selector for a Token in containerregistry to populate
+                      syncTokenId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -325,7 +329,8 @@ spec:
                       Connected Registry to be created.
                     type: string
                   containerRegistryIdRef:
-                    description: Reference to a Registry to populate containerRegistryId.
+                    description: Reference to a Registry in containerregistry to populate
+                      containerRegistryId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -359,7 +364,8 @@ spec:
                     - name
                     type: object
                   containerRegistryIdSelector:
-                    description: Selector for a Registry to populate containerRegistryId.
+                    description: Selector for a Registry in containerregistry to populate
+                      containerRegistryId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -452,7 +458,8 @@ spec:
                       a new Container Connected Registry to be created.
                     type: string
                   syncTokenIdRef:
-                    description: Reference to a Token to populate syncTokenId.
+                    description: Reference to a Token in containerregistry to populate
+                      syncTokenId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -486,7 +493,8 @@ spec:
                     - name
                     type: object
                   syncTokenIdSelector:
-                    description: Selector for a Token to populate syncTokenId.
+                    description: Selector for a Token in containerregistry to populate
+                      syncTokenId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/containerregistry.azure.upbound.io_tokens.yaml
+++ b/package/crds/containerregistry.azure.upbound.io_tokens.yaml
@@ -243,7 +243,8 @@ spec:
                       with the token.
                     type: string
                   scopeMapIdRef:
-                    description: Reference to a ScopeMap to populate scopeMapId.
+                    description: Reference to a ScopeMap in containerregistry to populate
+                      scopeMapId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -277,7 +278,8 @@ spec:
                     - name
                     type: object
                   scopeMapIdSelector:
-                    description: Selector for a ScopeMap to populate scopeMapId.
+                    description: Selector for a ScopeMap in containerregistry to populate
+                      scopeMapId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -339,7 +341,8 @@ spec:
                       with the token.
                     type: string
                   scopeMapIdRef:
-                    description: Reference to a ScopeMap to populate scopeMapId.
+                    description: Reference to a ScopeMap in containerregistry to populate
+                      scopeMapId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -373,7 +376,8 @@ spec:
                     - name
                     type: object
                   scopeMapIdSelector:
-                    description: Selector for a ScopeMap to populate scopeMapId.
+                    description: Selector for a ScopeMap in containerregistry to populate
+                      scopeMapId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/containerservice.azure.upbound.io_kubernetesclusternodepools.yaml
+++ b/package/crds/containerservice.azure.upbound.io_kubernetesclusternodepools.yaml
@@ -181,7 +181,8 @@ spec:
                       created.
                     type: string
                   kubernetesClusterIdRef:
-                    description: Reference to a KubernetesCluster to populate kubernetesClusterId.
+                    description: Reference to a KubernetesCluster in containerservice
+                      to populate kubernetesClusterId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -215,7 +216,8 @@ spec:
                     - name
                     type: object
                   kubernetesClusterIdSelector:
-                    description: Selector for a KubernetesCluster to populate kubernetesClusterId.
+                    description: Selector for a KubernetesCluster in containerservice
+                      to populate kubernetesClusterId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_accounts.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_accounts.yaml
@@ -472,7 +472,8 @@ spec:
                             Changing this forces a new resource to be created.
                           type: string
                         sourceCosmosdbAccountIdRef:
-                          description: Reference to a Account to populate sourceCosmosdbAccountId.
+                          description: Reference to a Account in cosmosdb to populate
+                            sourceCosmosdbAccountId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -506,7 +507,8 @@ spec:
                           - name
                           type: object
                         sourceCosmosdbAccountIdSelector:
-                          description: Selector for a Account to populate sourceCosmosdbAccountId.
+                          description: Selector for a Account in cosmosdb to populate
+                            sourceCosmosdbAccountId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -907,7 +909,8 @@ spec:
                             Changing this forces a new resource to be created.
                           type: string
                         sourceCosmosdbAccountIdRef:
-                          description: Reference to a Account to populate sourceCosmosdbAccountId.
+                          description: Reference to a Account in cosmosdb to populate
+                            sourceCosmosdbAccountId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -941,7 +944,8 @@ spec:
                           - name
                           type: object
                         sourceCosmosdbAccountIdSelector:
-                          description: Selector for a Account to populate sourceCosmosdbAccountId.
+                          description: Selector for a Account in cosmosdb to populate
+                            sourceCosmosdbAccountId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_cassandratables.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_cassandratables.yaml
@@ -96,7 +96,8 @@ spec:
                       created.
                     type: string
                   cassandraKeyspaceIdRef:
-                    description: Reference to a CassandraKeySpace to populate cassandraKeyspaceId.
+                    description: Reference to a CassandraKeySpace in cosmosdb to populate
+                      cassandraKeyspaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -130,7 +131,8 @@ spec:
                     - name
                     type: object
                   cassandraKeyspaceIdSelector:
-                    description: Selector for a CassandraKeySpace to populate cassandraKeyspaceId.
+                    description: Selector for a CassandraKeySpace in cosmosdb to populate
+                      cassandraKeyspaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_gremlindatabases.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_gremlindatabases.yaml
@@ -78,7 +78,7 @@ spec:
                       Database within. Changing this forces a new resource to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_gremlingraphs.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_gremlingraphs.yaml
@@ -78,7 +78,7 @@ spec:
                       Graph within. Changing this forces a new resource to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -194,7 +194,8 @@ spec:
                       a new resource to be created.
                     type: string
                   databaseNameRef:
-                    description: Reference to a GremlinDatabase to populate databaseName.
+                    description: Reference to a GremlinDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -228,7 +229,8 @@ spec:
                     - name
                     type: object
                   databaseNameSelector:
-                    description: Selector for a GremlinDatabase to populate databaseName.
+                    description: Selector for a GremlinDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_mongocollections.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_mongocollections.yaml
@@ -79,7 +79,7 @@ spec:
                       to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -176,7 +176,8 @@ spec:
                       a new resource to be created.
                     type: string
                   databaseNameRef:
-                    description: Reference to a MongoDatabase to populate databaseName.
+                    description: Reference to a MongoDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -210,7 +211,8 @@ spec:
                     - name
                     type: object
                   databaseNameSelector:
-                    description: Selector for a MongoDatabase to populate databaseName.
+                    description: Selector for a MongoDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_mongodatabases.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_mongodatabases.yaml
@@ -79,7 +79,7 @@ spec:
                       created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_sqlcontainers.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_sqlcontainers.yaml
@@ -78,7 +78,7 @@ spec:
                       within. Changing this forces a new resource to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -195,7 +195,8 @@ spec:
                       be created.
                     type: string
                   databaseNameRef:
-                    description: Reference to a SQLDatabase to populate databaseName.
+                    description: Reference to a SQLDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -229,7 +230,8 @@ spec:
                     - name
                     type: object
                   databaseNameSelector:
-                    description: Selector for a SQLDatabase to populate databaseName.
+                    description: Selector for a SQLDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_sqldatabases.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_sqldatabases.yaml
@@ -79,7 +79,7 @@ spec:
                       created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_sqlfunctions.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_sqlfunctions.yaml
@@ -82,7 +82,8 @@ spec:
                       SQL User Defined Function to be created.
                     type: string
                   containerIdRef:
-                    description: Reference to a SQLContainer to populate containerId.
+                    description: Reference to a SQLContainer in cosmosdb to populate
+                      containerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   containerIdSelector:
-                    description: Selector for a SQLContainer to populate containerId.
+                    description: Selector for a SQLContainer in cosmosdb to populate
+                      containerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_sqlstoredprocedures.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_sqlstoredprocedures.yaml
@@ -79,7 +79,7 @@ spec:
                       created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -161,7 +161,8 @@ spec:
                       to be created.
                     type: string
                   containerNameRef:
-                    description: Reference to a SQLContainer to populate containerName.
+                    description: Reference to a SQLContainer in cosmosdb to populate
+                      containerName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -195,7 +196,8 @@ spec:
                     - name
                     type: object
                   containerNameSelector:
-                    description: Selector for a SQLContainer to populate containerName.
+                    description: Selector for a SQLContainer in cosmosdb to populate
+                      containerName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -240,7 +242,8 @@ spec:
                       to be created.
                     type: string
                   databaseNameRef:
-                    description: Reference to a SQLDatabase to populate databaseName.
+                    description: Reference to a SQLDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -274,7 +277,8 @@ spec:
                     - name
                     type: object
                   databaseNameSelector:
-                    description: Selector for a SQLDatabase to populate databaseName.
+                    description: Selector for a SQLDatabase in cosmosdb to populate
+                      databaseName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_sqltriggers.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_sqltriggers.yaml
@@ -82,7 +82,8 @@ spec:
                       be created.
                     type: string
                   containerIdRef:
-                    description: Reference to a SQLContainer to populate containerId.
+                    description: Reference to a SQLContainer in cosmosdb to populate
+                      containerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   containerIdSelector:
-                    description: Selector for a SQLContainer to populate containerId.
+                    description: Selector for a SQLContainer in cosmosdb to populate
+                      containerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cosmosdb.azure.upbound.io_tables.yaml
+++ b/package/crds/cosmosdb.azure.upbound.io_tables.yaml
@@ -78,7 +78,7 @@ spec:
                       within. Changing this forces a new resource to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in cosmosdb to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in cosmosdb to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dataprotection.azure.upbound.io_backuppolicyblobstorages.yaml
+++ b/package/crds/dataprotection.azure.upbound.io_backuppolicyblobstorages.yaml
@@ -85,7 +85,8 @@ spec:
                       Backup Policy Blob Storage to be created.
                     type: string
                   vaultIdRef:
-                    description: Reference to a BackupVault to populate vaultId.
+                    description: Reference to a BackupVault in dataprotection to populate
+                      vaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,7 +120,8 @@ spec:
                     - name
                     type: object
                   vaultIdSelector:
-                    description: Selector for a BackupVault to populate vaultId.
+                    description: Selector for a BackupVault in dataprotection to populate
+                      vaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dataprotection.azure.upbound.io_backuppolicydisks.yaml
+++ b/package/crds/dataprotection.azure.upbound.io_backuppolicydisks.yaml
@@ -129,7 +129,8 @@ spec:
                       Policy Disk to be created.
                     type: string
                   vaultIdRef:
-                    description: Reference to a BackupVault to populate vaultId.
+                    description: Reference to a BackupVault in dataprotection to populate
+                      vaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -163,7 +164,8 @@ spec:
                     - name
                     type: object
                   vaultIdSelector:
-                    description: Selector for a BackupVault to populate vaultId.
+                    description: Selector for a BackupVault in dataprotection to populate
+                      vaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dataprotection.azure.upbound.io_backuppolicypostgresqls.yaml
+++ b/package/crds/dataprotection.azure.upbound.io_backuppolicypostgresqls.yaml
@@ -248,7 +248,8 @@ spec:
                       PostgreSQL to be created.
                     type: string
                   vaultNameRef:
-                    description: Reference to a BackupVault to populate vaultName.
+                    description: Reference to a BackupVault in dataprotection to populate
+                      vaultName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -282,7 +283,8 @@ spec:
                     - name
                     type: object
                   vaultNameSelector:
-                    description: Selector for a BackupVault to populate vaultName.
+                    description: Selector for a BackupVault in dataprotection to populate
+                      vaultName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/datashare.azure.upbound.io_datasetblobstorages.yaml
+++ b/package/crds/datashare.azure.upbound.io_datasetblobstorages.yaml
@@ -158,7 +158,8 @@ spec:
                       a new Data Share Blob Storage Dataset to be created.
                     type: string
                   dataShareIdRef:
-                    description: Reference to a DataShare to populate dataShareId.
+                    description: Reference to a DataShare in datashare to populate
+                      dataShareId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +193,8 @@ spec:
                     - name
                     type: object
                   dataShareIdSelector:
-                    description: Selector for a DataShare to populate dataShareId.
+                    description: Selector for a DataShare in datashare to populate
+                      dataShareId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/datashare.azure.upbound.io_datasetdatalakegen2s.yaml
+++ b/package/crds/datashare.azure.upbound.io_datasetdatalakegen2s.yaml
@@ -170,7 +170,8 @@ spec:
                       forces a new Data Share Data Lake Gen2 Dataset to be created.
                     type: string
                   shareIdRef:
-                    description: Reference to a DataShare to populate shareId.
+                    description: Reference to a DataShare in datashare to populate
+                      shareId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -204,7 +205,8 @@ spec:
                     - name
                     type: object
                   shareIdSelector:
-                    description: Selector for a DataShare to populate shareId.
+                    description: Selector for a DataShare in datashare to populate
+                      shareId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/datashare.azure.upbound.io_datasetkustoclusters.yaml
+++ b/package/crds/datashare.azure.upbound.io_datasetkustoclusters.yaml
@@ -158,7 +158,8 @@ spec:
                       forces a new Data Share Kusto Cluster Dataset to be created.
                     type: string
                   shareIdRef:
-                    description: Reference to a DataShare to populate shareId.
+                    description: Reference to a DataShare in datashare to populate
+                      shareId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +193,8 @@ spec:
                     - name
                     type: object
                   shareIdSelector:
-                    description: Selector for a DataShare to populate shareId.
+                    description: Selector for a DataShare in datashare to populate
+                      shareId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/datashare.azure.upbound.io_datasetkustodatabases.yaml
+++ b/package/crds/datashare.azure.upbound.io_datasetkustodatabases.yaml
@@ -158,7 +158,8 @@ spec:
                       forces a new Data Share Kusto Database Dataset to be created.
                     type: string
                   shareIdRef:
-                    description: Reference to a DataShare to populate shareId.
+                    description: Reference to a DataShare in datashare to populate
+                      shareId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +193,8 @@ spec:
                     - name
                     type: object
                   shareIdSelector:
-                    description: Selector for a DataShare to populate shareId.
+                    description: Selector for a DataShare in datashare to populate
+                      shareId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/datashare.azure.upbound.io_datashares.yaml
+++ b/package/crds/datashare.azure.upbound.io_datashares.yaml
@@ -79,7 +79,7 @@ spec:
                       created.
                     type: string
                   accountIdRef:
-                    description: Reference to a Account to populate accountId.
+                    description: Reference to a Account in datashare to populate accountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountIdSelector:
-                    description: Selector for a Account to populate accountId.
+                    description: Selector for a Account in datashare to populate accountId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbformariadb.azure.upbound.io_firewallrules.yaml
+++ b/package/crds/dbformariadb.azure.upbound.io_firewallrules.yaml
@@ -162,7 +162,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbformariadb to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -196,7 +197,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbformariadb to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbformariadb.azure.upbound.io_servers.yaml
+++ b/package/crds/dbformariadb.azure.upbound.io_servers.yaml
@@ -115,7 +115,8 @@ spec:
                       server ID to use.
                     type: string
                   creationSourceServerIdRef:
-                    description: Reference to a Server to populate creationSourceServerId.
+                    description: Reference to a Server in dbformariadb to populate
+                      creationSourceServerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -149,7 +150,8 @@ spec:
                     - name
                     type: object
                   creationSourceServerIdSelector:
-                    description: Selector for a Server to populate creationSourceServerId.
+                    description: Selector for a Server in dbformariadb to populate
+                      creationSourceServerId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -367,7 +369,8 @@ spec:
                       server ID to use.
                     type: string
                   creationSourceServerIdRef:
-                    description: Reference to a Server to populate creationSourceServerId.
+                    description: Reference to a Server in dbformariadb to populate
+                      creationSourceServerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -401,7 +404,8 @@ spec:
                     - name
                     type: object
                   creationSourceServerIdSelector:
-                    description: Selector for a Server to populate creationSourceServerId.
+                    description: Selector for a Server in dbformariadb to populate
+                      creationSourceServerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbformysql.azure.upbound.io_flexibledatabases.yaml
+++ b/package/crds/dbformysql.azure.upbound.io_flexibledatabases.yaml
@@ -168,7 +168,8 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a FlexibleServer to populate serverName.
+                    description: Reference to a FlexibleServer in dbformysql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -202,7 +203,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a FlexibleServer to populate serverName.
+                    description: Selector for a FlexibleServer in dbformysql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbformysql.azure.upbound.io_flexibleserverconfigurations.yaml
+++ b/package/crds/dbformysql.azure.upbound.io_flexibleserverconfigurations.yaml
@@ -161,7 +161,8 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a FlexibleServer to populate serverName.
+                    description: Reference to a FlexibleServer in dbformysql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -195,7 +196,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a FlexibleServer to populate serverName.
+                    description: Selector for a FlexibleServer in dbformysql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbformysql.azure.upbound.io_flexibleserverfirewallrules.yaml
+++ b/package/crds/dbformysql.azure.upbound.io_flexibleserverfirewallrules.yaml
@@ -164,7 +164,8 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a FlexibleServer to populate serverName.
+                    description: Reference to a FlexibleServer in dbformysql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -198,7 +199,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a FlexibleServer to populate serverName.
+                    description: Selector for a FlexibleServer in dbformysql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_activedirectoryadministrators.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_activedirectoryadministrators.yaml
@@ -168,7 +168,8 @@ spec:
                       created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -202,7 +203,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_configurations.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_configurations.yaml
@@ -163,7 +163,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -197,7 +198,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -345,7 +347,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -379,7 +382,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_databases.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_databases.yaml
@@ -169,7 +169,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -203,7 +204,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_firewallrules.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_firewallrules.yaml
@@ -162,7 +162,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -196,7 +197,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_flexibleserveractivedirectoryadministrators.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_flexibleserveractivedirectoryadministrators.yaml
@@ -175,7 +175,8 @@ spec:
                       to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a FlexibleServer to populate serverName.
+                    description: Reference to a FlexibleServer in dbforpostgresql
+                      to populate serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -209,7 +210,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a FlexibleServer to populate serverName.
+                    description: Selector for a FlexibleServer in dbforpostgresql
+                      to populate serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_flexibleserverconfigurations.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_flexibleserverconfigurations.yaml
@@ -86,7 +86,8 @@ spec:
                       Flexible Server Configuration resource.
                     type: string
                   serverIdRef:
-                    description: Reference to a FlexibleServer to populate serverId.
+                    description: Reference to a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -120,7 +121,8 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a FlexibleServer to populate serverId.
+                    description: Selector for a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -188,7 +190,8 @@ spec:
                       Flexible Server Configuration resource.
                     type: string
                   serverIdRef:
-                    description: Reference to a FlexibleServer to populate serverId.
+                    description: Reference to a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -222,7 +225,8 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a FlexibleServer to populate serverId.
+                    description: Selector for a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_flexibleserverdatabases.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_flexibleserverdatabases.yaml
@@ -92,7 +92,8 @@ spec:
                       to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a FlexibleServer to populate serverId.
+                    description: Reference to a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +127,8 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a FlexibleServer to populate serverId.
+                    description: Selector for a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_flexibleserverfirewallrules.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_flexibleserverfirewallrules.yaml
@@ -85,7 +85,8 @@ spec:
                       be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a FlexibleServer to populate serverId.
+                    description: Reference to a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,7 +120,8 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a FlexibleServer to populate serverId.
+                    description: Selector for a FlexibleServer in dbforpostgresql
+                      to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_serverkeys.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_serverkeys.yaml
@@ -155,7 +155,8 @@ spec:
                       a new resource to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a Server to populate serverId.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -189,7 +190,8 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a Server to populate serverId.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -324,7 +326,8 @@ spec:
                       a new resource to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a Server to populate serverId.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -358,7 +361,8 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a Server to populate serverId.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dbforpostgresql.azure.upbound.io_virtualnetworkrules.yaml
+++ b/package/crds/dbforpostgresql.azure.upbound.io_virtualnetworkrules.yaml
@@ -163,7 +163,8 @@ spec:
                       a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a Server to populate serverName.
+                    description: Reference to a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -197,7 +198,8 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a Server to populate serverName.
+                    description: Selector for a Server in dbforpostgresql to populate
+                      serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/devices.azure.upbound.io_iothubconsumergroups.yaml
+++ b/package/crds/devices.azure.upbound.io_iothubconsumergroups.yaml
@@ -82,7 +82,7 @@ spec:
                       resource to be created.
                     type: string
                   iothubNameRef:
-                    description: Reference to a IOTHub to populate iothubName.
+                    description: Reference to a IOTHub in devices to populate iothubName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +116,7 @@ spec:
                     - name
                     type: object
                   iothubNameSelector:
-                    description: Selector for a IOTHub to populate iothubName.
+                    description: Selector for a IOTHub in devices to populate iothubName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/devices.azure.upbound.io_iothubdpscertificates.yaml
+++ b/package/crds/devices.azure.upbound.io_iothubdpscertificates.yaml
@@ -97,7 +97,7 @@ spec:
                       new resource to be created.
                     type: string
                   iotDpsNameRef:
-                    description: Reference to a IOTHubDPS to populate iotDpsName.
+                    description: Reference to a IOTHubDPS in devices to populate iotDpsName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -131,7 +131,7 @@ spec:
                     - name
                     type: object
                   iotDpsNameSelector:
-                    description: Selector for a IOTHubDPS to populate iotDpsName.
+                    description: Selector for a IOTHubDPS in devices to populate iotDpsName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -276,7 +276,7 @@ spec:
                       new resource to be created.
                     type: string
                   iotDpsNameRef:
-                    description: Reference to a IOTHubDPS to populate iotDpsName.
+                    description: Reference to a IOTHubDPS in devices to populate iotDpsName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -310,7 +310,7 @@ spec:
                     - name
                     type: object
                   iotDpsNameSelector:
-                    description: Selector for a IOTHubDPS to populate iotDpsName.
+                    description: Selector for a IOTHubDPS in devices to populate iotDpsName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/devices.azure.upbound.io_iothubfallbackroutes.yaml
+++ b/package/crds/devices.azure.upbound.io_iothubfallbackroutes.yaml
@@ -88,8 +88,8 @@ spec:
                       type: string
                     type: array
                   endpointNamesRefs:
-                    description: References to IOTHubEndpointStorageContainer to populate
-                      endpointNames.
+                    description: References to IOTHubEndpointStorageContainer in devices
+                      to populate endpointNames.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -127,7 +127,7 @@ spec:
                     type: array
                   endpointNamesSelector:
                     description: Selector for a list of IOTHubEndpointStorageContainer
-                      to populate endpointNames.
+                      in devices to populate endpointNames.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -171,7 +171,7 @@ spec:
                       belongs. Changing this forces a new resource to be created.
                     type: string
                   iothubNameRef:
-                    description: Reference to a IOTHub to populate iothubName.
+                    description: Reference to a IOTHub in devices to populate iothubName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -205,7 +205,7 @@ spec:
                     - name
                     type: object
                   iothubNameSelector:
-                    description: Selector for a IOTHub to populate iothubName.
+                    description: Selector for a IOTHub in devices to populate iothubName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -360,8 +360,8 @@ spec:
                       type: string
                     type: array
                   endpointNamesRefs:
-                    description: References to IOTHubEndpointStorageContainer to populate
-                      endpointNames.
+                    description: References to IOTHubEndpointStorageContainer in devices
+                      to populate endpointNames.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -399,7 +399,7 @@ spec:
                     type: array
                   endpointNamesSelector:
                     description: Selector for a list of IOTHubEndpointStorageContainer
-                      to populate endpointNames.
+                      in devices to populate endpointNames.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eventhub.azure.upbound.io_authorizationrules.yaml
+++ b/package/crds/eventhub.azure.upbound.io_authorizationrules.yaml
@@ -78,7 +78,7 @@ spec:
                       forces a new resource to be created.
                     type: string
                   eventhubNameRef:
-                    description: Reference to a EventHub to populate eventhubName.
+                    description: Reference to a EventHub in eventhub to populate eventhubName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   eventhubNameSelector:
-                    description: Selector for a EventHub to populate eventhubName.
+                    description: Selector for a EventHub in eventhub to populate eventhubName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -165,7 +165,8 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   namespaceNameRef:
-                    description: Reference to a EventHubNamespace to populate namespaceName.
+                    description: Reference to a EventHubNamespace in eventhub to populate
+                      namespaceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -199,7 +200,8 @@ spec:
                     - name
                     type: object
                   namespaceNameSelector:
-                    description: Selector for a EventHubNamespace to populate namespaceName.
+                    description: Selector for a EventHubNamespace in eventhub to populate
+                      namespaceName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eventhub.azure.upbound.io_consumergroups.yaml
+++ b/package/crds/eventhub.azure.upbound.io_consumergroups.yaml
@@ -78,7 +78,7 @@ spec:
                       forces a new resource to be created.
                     type: string
                   eventhubNameRef:
-                    description: Reference to a EventHub to populate eventhubName.
+                    description: Reference to a EventHub in eventhub to populate eventhubName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   eventhubNameSelector:
-                    description: Selector for a EventHub to populate eventhubName.
+                    description: Selector for a EventHub in eventhub to populate eventhubName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -156,7 +156,8 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   namespaceNameRef:
-                    description: Reference to a EventHubNamespace to populate namespaceName.
+                    description: Reference to a EventHubNamespace in eventhub to populate
+                      namespaceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -190,7 +191,8 @@ spec:
                     - name
                     type: object
                   namespaceNameSelector:
-                    description: Selector for a EventHubNamespace to populate namespaceName.
+                    description: Selector for a EventHubNamespace in eventhub to populate
+                      namespaceName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eventhub.azure.upbound.io_eventhubs.yaml
+++ b/package/crds/eventhub.azure.upbound.io_eventhubs.yaml
@@ -135,7 +135,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   namespaceNameRef:
-                    description: Reference to a EventHubNamespace to populate namespaceName.
+                    description: Reference to a EventHubNamespace in eventhub to populate
+                      namespaceName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -169,7 +170,8 @@ spec:
                     - name
                     type: object
                   namespaceNameSelector:
-                    description: Selector for a EventHubNamespace to populate namespaceName.
+                    description: Selector for a EventHubNamespace in eventhub to populate
+                      namespaceName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/healthcareapis.azure.upbound.io_healthcaremedtechservicefhirdestinations.yaml
+++ b/package/crds/healthcareapis.azure.upbound.io_healthcaremedtechservicefhirdestinations.yaml
@@ -84,8 +84,8 @@ spec:
                       Med Tech Service Fhir Destination.
                     type: string
                   destinationFhirServiceIdRef:
-                    description: Reference to a HealthcareFHIRService to populate
-                      destinationFhirServiceId.
+                    description: Reference to a HealthcareFHIRService in healthcareapis
+                      to populate destinationFhirServiceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,8 +119,8 @@ spec:
                     - name
                     type: object
                   destinationFhirServiceIdSelector:
-                    description: Selector for a HealthcareFHIRService to populate
-                      destinationFhirServiceId.
+                    description: Selector for a HealthcareFHIRService in healthcareapis
+                      to populate destinationFhirServiceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -177,8 +177,8 @@ spec:
                       Fhir Destination to be created.
                     type: string
                   medtechServiceIdRef:
-                    description: Reference to a HealthcareMedtechService to populate
-                      medtechServiceId.
+                    description: Reference to a HealthcareMedtechService in healthcareapis
+                      to populate medtechServiceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -212,8 +212,8 @@ spec:
                     - name
                     type: object
                   medtechServiceIdSelector:
-                    description: Selector for a HealthcareMedtechService to populate
-                      medtechServiceId.
+                    description: Selector for a HealthcareMedtechService in healthcareapis
+                      to populate medtechServiceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -275,8 +275,8 @@ spec:
                       Med Tech Service Fhir Destination.
                     type: string
                   destinationFhirServiceIdRef:
-                    description: Reference to a HealthcareFHIRService to populate
-                      destinationFhirServiceId.
+                    description: Reference to a HealthcareFHIRService in healthcareapis
+                      to populate destinationFhirServiceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -310,8 +310,8 @@ spec:
                     - name
                     type: object
                   destinationFhirServiceIdSelector:
-                    description: Selector for a HealthcareFHIRService to populate
-                      destinationFhirServiceId.
+                    description: Selector for a HealthcareFHIRService in healthcareapis
+                      to populate destinationFhirServiceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/healthcareapis.azure.upbound.io_healthcaremedtechservices.yaml
+++ b/package/crds/healthcareapis.azure.upbound.io_healthcaremedtechservices.yaml
@@ -350,7 +350,8 @@ spec:
                       forces a new Healthcare Med Tech Service to be created.
                     type: string
                   workspaceIdRef:
-                    description: Reference to a HealthcareWorkspace to populate workspaceId.
+                    description: Reference to a HealthcareWorkspace in healthcareapis
+                      to populate workspaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -384,7 +385,8 @@ spec:
                     - name
                     type: object
                   workspaceIdSelector:
-                    description: Selector for a HealthcareWorkspace to populate workspaceId.
+                    description: Selector for a HealthcareWorkspace in healthcareapis
+                      to populate workspaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/insights.azure.upbound.io_monitormetricalerts.yaml
+++ b/package/crds/insights.azure.upbound.io_monitormetricalerts.yaml
@@ -82,8 +82,8 @@ spec:
                             the
                           type: string
                         actionGroupIdRef:
-                          description: Reference to a MonitorActionGroup to populate
-                            actionGroupId.
+                          description: Reference to a MonitorActionGroup in insights
+                            to populate actionGroupId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -117,8 +117,8 @@ spec:
                           - name
                           type: object
                         actionGroupIdSelector:
-                          description: Selector for a MonitorActionGroup to populate
-                            actionGroupId.
+                          description: Selector for a MonitorActionGroup in insights
+                            to populate actionGroupId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -527,8 +527,8 @@ spec:
                             the
                           type: string
                         actionGroupIdRef:
-                          description: Reference to a MonitorActionGroup to populate
-                            actionGroupId.
+                          description: Reference to a MonitorActionGroup in insights
+                            to populate actionGroupId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -562,8 +562,8 @@ spec:
                           - name
                           type: object
                         actionGroupIdSelector:
-                          description: Selector for a MonitorActionGroup to populate
-                            actionGroupId.
+                          description: Selector for a MonitorActionGroup in insights
+                            to populate actionGroupId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/insights.azure.upbound.io_monitorprivatelinkscopedservices.yaml
+++ b/package/crds/insights.azure.upbound.io_monitorprivatelinkscopedservices.yaml
@@ -81,7 +81,8 @@ spec:
                       to be created.
                     type: string
                   linkedResourceIdRef:
-                    description: Reference to a ApplicationInsights to populate linkedResourceId.
+                    description: Reference to a ApplicationInsights in insights to
+                      populate linkedResourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -115,7 +116,8 @@ spec:
                     - name
                     type: object
                   linkedResourceIdSelector:
-                    description: Selector for a ApplicationInsights to populate linkedResourceId.
+                    description: Selector for a ApplicationInsights in insights to
+                      populate linkedResourceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -240,8 +242,8 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   scopeNameRef:
-                    description: Reference to a MonitorPrivateLinkScope to populate
-                      scopeName.
+                    description: Reference to a MonitorPrivateLinkScope in insights
+                      to populate scopeName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -275,8 +277,8 @@ spec:
                     - name
                     type: object
                   scopeNameSelector:
-                    description: Selector for a MonitorPrivateLinkScope to populate
-                      scopeName.
+                    description: Selector for a MonitorPrivateLinkScope in insights
+                      to populate scopeName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -336,7 +338,8 @@ spec:
                       to be created.
                     type: string
                   linkedResourceIdRef:
-                    description: Reference to a ApplicationInsights to populate linkedResourceId.
+                    description: Reference to a ApplicationInsights in insights to
+                      populate linkedResourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -370,7 +373,8 @@ spec:
                     - name
                     type: object
                   linkedResourceIdSelector:
-                    description: Selector for a ApplicationInsights to populate linkedResourceId.
+                    description: Selector for a ApplicationInsights in insights to
+                      populate linkedResourceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/insights.azure.upbound.io_monitorscheduledqueryrulesalerts.yaml
+++ b/package/crds/insights.azure.upbound.io_monitorscheduledqueryrulesalerts.yaml
@@ -86,8 +86,8 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         actionGroupRefs:
-                          description: References to MonitorActionGroup to populate
-                            actionGroup.
+                          description: References to MonitorActionGroup in insights
+                            to populate actionGroup.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -124,8 +124,8 @@ spec:
                             type: object
                           type: array
                         actionGroupSelector:
-                          description: Selector for a list of MonitorActionGroup to
-                            populate actionGroup.
+                          description: Selector for a list of MonitorActionGroup in
+                            insights to populate actionGroup.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -458,8 +458,8 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         actionGroupRefs:
-                          description: References to MonitorActionGroup to populate
-                            actionGroup.
+                          description: References to MonitorActionGroup in insights
+                            to populate actionGroup.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -496,8 +496,8 @@ spec:
                             type: object
                           type: array
                         actionGroupSelector:
-                          description: Selector for a list of MonitorActionGroup to
-                            populate actionGroup.
+                          description: Selector for a list of MonitorActionGroup in
+                            insights to populate actionGroup.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/insights.azure.upbound.io_monitorscheduledqueryrulesalertv2s.yaml
+++ b/package/crds/insights.azure.upbound.io_monitorscheduledqueryrulesalertv2s.yaml
@@ -296,7 +296,8 @@ spec:
                       type: string
                     type: array
                   scopesRefs:
-                    description: References to ApplicationInsights to populate scopes.
+                    description: References to ApplicationInsights in insights to
+                      populate scopes.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -333,8 +334,8 @@ spec:
                       type: object
                     type: array
                   scopesSelector:
-                    description: Selector for a list of ApplicationInsights to populate
-                      scopes.
+                    description: Selector for a list of ApplicationInsights in insights
+                      to populate scopes.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -565,7 +566,8 @@ spec:
                       type: string
                     type: array
                   scopesRefs:
-                    description: References to ApplicationInsights to populate scopes.
+                    description: References to ApplicationInsights in insights to
+                      populate scopes.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -602,8 +604,8 @@ spec:
                       type: object
                     type: array
                   scopesSelector:
-                    description: Selector for a list of ApplicationInsights to populate
-                      scopes.
+                    description: Selector for a list of ApplicationInsights in insights
+                      to populate scopes.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_accesspolicies.yaml
+++ b/package/crds/keyvault.azure.upbound.io_accesspolicies.yaml
@@ -98,7 +98,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -132,7 +132,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -237,7 +237,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -271,7 +271,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_certificateissuers.yaml
+++ b/package/crds/keyvault.azure.upbound.io_certificateissuers.yaml
@@ -100,7 +100,7 @@ spec:
                       Issuer. Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -134,7 +134,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -241,7 +241,7 @@ spec:
                       Issuer. Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -275,7 +275,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_certificates.yaml
+++ b/package/crds/keyvault.azure.upbound.io_certificates.yaml
@@ -271,7 +271,7 @@ spec:
                       be created. Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -305,7 +305,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -529,7 +529,7 @@ spec:
                       be created. Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -563,7 +563,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_keys.yaml
+++ b/package/crds/keyvault.azure.upbound.io_keys.yaml
@@ -108,7 +108,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -142,7 +142,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -272,7 +272,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -306,7 +306,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_managedstorageaccounts.yaml
+++ b/package/crds/keyvault.azure.upbound.io_managedstorageaccounts.yaml
@@ -79,7 +79,7 @@ spec:
                       to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -269,7 +269,7 @@ spec:
                       to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -303,7 +303,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_managedstorageaccountsastokendefinitions.yaml
+++ b/package/crds/keyvault.azure.upbound.io_managedstorageaccountsastokendefinitions.yaml
@@ -79,8 +79,8 @@ spec:
                     description: The ID of the Managed Storage Account.
                     type: string
                   managedStorageAccountIdRef:
-                    description: Reference to a ManagedStorageAccount to populate
-                      managedStorageAccountId.
+                    description: Reference to a ManagedStorageAccount in keyvault
+                      to populate managedStorageAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,8 +114,8 @@ spec:
                     - name
                     type: object
                   managedStorageAccountIdSelector:
-                    description: Selector for a ManagedStorageAccount to populate
-                      managedStorageAccountId.
+                    description: Selector for a ManagedStorageAccount in keyvault
+                      to populate managedStorageAccountId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/keyvault.azure.upbound.io_secrets.yaml
+++ b/package/crds/keyvault.azure.upbound.io_secrets.yaml
@@ -84,7 +84,7 @@ spec:
                       created. Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -213,7 +213,7 @@ spec:
                       created. Changing this forces a new resource to be created.
                     type: string
                   keyVaultIdRef:
-                    description: Reference to a Vault to populate keyVaultId.
+                    description: Reference to a Vault in keyvault to populate keyVaultId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -247,7 +247,7 @@ spec:
                     - name
                     type: object
                   keyVaultIdSelector:
-                    description: Selector for a Vault to populate keyVaultId.
+                    description: Selector for a Vault in keyvault to populate keyVaultId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kusto.azure.upbound.io_databases.yaml
+++ b/package/crds/kusto.azure.upbound.io_databases.yaml
@@ -79,7 +79,7 @@ spec:
                       created.
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in kusto to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in kusto to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/management.azure.upbound.io_managementgroupsubscriptionassociations.yaml
+++ b/package/crds/management.azure.upbound.io_managementgroupsubscriptionassociations.yaml
@@ -80,7 +80,8 @@ spec:
                       with. Changing this forces a new Management to be created.
                     type: string
                   managementGroupIdRef:
-                    description: Reference to a ManagementGroup to populate managementGroupId.
+                    description: Reference to a ManagementGroup in management to populate
+                      managementGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   managementGroupIdSelector:
-                    description: Selector for a ManagementGroup to populate managementGroupId.
+                    description: Selector for a ManagementGroup in management to populate
+                      managementGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -253,7 +255,8 @@ spec:
                       with. Changing this forces a new Management to be created.
                     type: string
                   managementGroupIdRef:
-                    description: Reference to a ManagementGroup to populate managementGroupId.
+                    description: Reference to a ManagementGroup in management to populate
+                      managementGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -287,7 +290,8 @@ spec:
                     - name
                     type: object
                   managementGroupIdSelector:
-                    description: Selector for a ManagementGroup to populate managementGroupId.
+                    description: Selector for a ManagementGroup in management to populate
+                      managementGroupId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_assets.yaml
+++ b/package/crds/media.azure.upbound.io_assets.yaml
@@ -87,7 +87,8 @@ spec:
                       Changing this forces a new Media Asset to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +122,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_liveeventoutputs.yaml
+++ b/package/crds/media.azure.upbound.io_liveeventoutputs.yaml
@@ -86,7 +86,7 @@ spec:
                       this forces a new Live Output to be created.
                     type: string
                   assetNameRef:
-                    description: Reference to a Asset to populate assetName.
+                    description: Reference to a Asset in media to populate assetName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -120,7 +120,7 @@ spec:
                     - name
                     type: object
                   assetNameSelector:
-                    description: Selector for a Asset to populate assetName.
+                    description: Selector for a Asset in media to populate assetName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -174,7 +174,7 @@ spec:
                       new Live Output to be created.
                     type: string
                   liveEventIdRef:
-                    description: Reference to a LiveEvent to populate liveEventId.
+                    description: Reference to a LiveEvent in media to populate liveEventId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -208,7 +208,7 @@ spec:
                     - name
                     type: object
                   liveEventIdSelector:
-                    description: Selector for a LiveEvent to populate liveEventId.
+                    description: Selector for a LiveEvent in media to populate liveEventId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -294,7 +294,7 @@ spec:
                       this forces a new Live Output to be created.
                     type: string
                   assetNameRef:
-                    description: Reference to a Asset to populate assetName.
+                    description: Reference to a Asset in media to populate assetName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -328,7 +328,7 @@ spec:
                     - name
                     type: object
                   assetNameSelector:
-                    description: Selector for a Asset to populate assetName.
+                    description: Selector for a Asset in media to populate assetName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_liveevents.yaml
+++ b/package/crds/media.azure.upbound.io_liveevents.yaml
@@ -189,7 +189,8 @@ spec:
                       a new Live Event to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -223,7 +224,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_servicesaccountfilters.yaml
+++ b/package/crds/media.azure.upbound.io_servicesaccountfilters.yaml
@@ -84,7 +84,8 @@ spec:
                       a new Account Filter to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +119,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_streamingendpoints.yaml
+++ b/package/crds/media.azure.upbound.io_streamingendpoints.yaml
@@ -160,7 +160,8 @@ spec:
                       a new Streaming Endpoint to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -194,7 +195,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_streaminglocators.yaml
+++ b/package/crds/media.azure.upbound.io_streaminglocators.yaml
@@ -82,7 +82,7 @@ spec:
                       Locator to be created.
                     type: string
                   assetNameRef:
-                    description: Reference to a Asset to populate assetName.
+                    description: Reference to a Asset in media to populate assetName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +116,7 @@ spec:
                     - name
                     type: object
                   assetNameSelector:
-                    description: Selector for a Asset to populate assetName.
+                    description: Selector for a Asset in media to populate assetName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -205,7 +205,8 @@ spec:
                       a new Streaming Locator to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -239,7 +240,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -399,7 +401,7 @@ spec:
                       Locator to be created.
                     type: string
                   assetNameRef:
-                    description: Reference to a Asset to populate assetName.
+                    description: Reference to a Asset in media to populate assetName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -433,7 +435,7 @@ spec:
                     - name
                     type: object
                   assetNameSelector:
-                    description: Selector for a Asset to populate assetName.
+                    description: Selector for a Asset in media to populate assetName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_streamingpolicies.yaml
+++ b/package/crds/media.azure.upbound.io_streamingpolicies.yaml
@@ -455,7 +455,8 @@ spec:
                       a new Streaming Policy to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -489,7 +490,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/media.azure.upbound.io_transforms.yaml
+++ b/package/crds/media.azure.upbound.io_transforms.yaml
@@ -80,7 +80,8 @@ spec:
                       a new Transform to be created.
                     type: string
                   mediaServicesAccountNameRef:
-                    description: Reference to a ServicesAccount to populate mediaServicesAccountName.
+                    description: Reference to a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   mediaServicesAccountNameSelector:
-                    description: Selector for a ServicesAccount to populate mediaServicesAccountName.
+                    description: Selector for a ServicesAccount in media to populate
+                      mediaServicesAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/netapp.azure.upbound.io_pools.yaml
+++ b/package/crds/netapp.azure.upbound.io_pools.yaml
@@ -79,7 +79,7 @@ spec:
                       to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in netapp to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in netapp to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/netapp.azure.upbound.io_snapshotpolicies.yaml
+++ b/package/crds/netapp.azure.upbound.io_snapshotpolicies.yaml
@@ -79,7 +79,7 @@ spec:
                       resource to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in netapp to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in netapp to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/netapp.azure.upbound.io_snapshots.yaml
+++ b/package/crds/netapp.azure.upbound.io_snapshots.yaml
@@ -79,7 +79,7 @@ spec:
                       to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in netapp to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in netapp to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -162,7 +162,7 @@ spec:
                       created.
                     type: string
                   poolNameRef:
-                    description: Reference to a Pool to populate poolName.
+                    description: Reference to a Pool in netapp to populate poolName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -196,7 +196,7 @@ spec:
                     - name
                     type: object
                   poolNameSelector:
-                    description: Selector for a Pool to populate poolName.
+                    description: Selector for a Pool in netapp to populate poolName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -322,7 +322,7 @@ spec:
                       to be created.
                     type: string
                   volumeNameRef:
-                    description: Reference to a Volume to populate volumeName.
+                    description: Reference to a Volume in netapp to populate volumeName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -356,7 +356,7 @@ spec:
                     - name
                     type: object
                   volumeNameSelector:
-                    description: Selector for a Volume to populate volumeName.
+                    description: Selector for a Volume in netapp to populate volumeName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/netapp.azure.upbound.io_volumes.yaml
+++ b/package/crds/netapp.azure.upbound.io_volumes.yaml
@@ -78,7 +78,7 @@ spec:
                       to be created.
                     type: string
                   accountNameRef:
-                    description: Reference to a Account to populate accountName.
+                    description: Reference to a Account in netapp to populate accountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   accountNameSelector:
-                    description: Selector for a Account to populate accountName.
+                    description: Selector for a Account in netapp to populate accountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -164,7 +164,7 @@ spec:
                       to be created.'
                     type: string
                   createFromSnapshotResourceIdRef:
-                    description: Reference to a Snapshot to populate createFromSnapshotResourceId.
+                    description: Reference to a Snapshot in netapp to populate createFromSnapshotResourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -198,7 +198,7 @@ spec:
                     - name
                     type: object
                   createFromSnapshotResourceIdSelector:
-                    description: Selector for a Snapshot to populate createFromSnapshotResourceId.
+                    description: Selector for a Snapshot in netapp to populate createFromSnapshotResourceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -254,7 +254,8 @@ spec:
                           description: Resource ID of the primary volume.
                           type: string
                         remoteVolumeResourceIdRef:
-                          description: Reference to a Volume to populate remoteVolumeResourceId.
+                          description: Reference to a Volume in netapp to populate
+                            remoteVolumeResourceId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -288,7 +289,8 @@ spec:
                           - name
                           type: object
                         remoteVolumeResourceIdSelector:
-                          description: Selector for a Volume to populate remoteVolumeResourceId.
+                          description: Selector for a Volume in netapp to populate
+                            remoteVolumeResourceId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -343,7 +345,8 @@ spec:
                             to the volume.
                           type: string
                         snapshotPolicyIdRef:
-                          description: Reference to a SnapshotPolicy to populate snapshotPolicyId.
+                          description: Reference to a SnapshotPolicy in netapp to
+                            populate snapshotPolicyId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -377,7 +380,8 @@ spec:
                           - name
                           type: object
                         snapshotPolicyIdSelector:
-                          description: Selector for a SnapshotPolicy to populate snapshotPolicyId.
+                          description: Selector for a SnapshotPolicy in netapp to
+                            populate snapshotPolicyId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -478,7 +482,7 @@ spec:
                       created.
                     type: string
                   poolNameRef:
-                    description: Reference to a Pool to populate poolName.
+                    description: Reference to a Pool in netapp to populate poolName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -512,7 +516,7 @@ spec:
                     - name
                     type: object
                   poolNameSelector:
-                    description: Selector for a Pool to populate poolName.
+                    description: Selector for a Pool in netapp to populate poolName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -809,7 +813,7 @@ spec:
                       to be created.'
                     type: string
                   createFromSnapshotResourceIdRef:
-                    description: Reference to a Snapshot to populate createFromSnapshotResourceId.
+                    description: Reference to a Snapshot in netapp to populate createFromSnapshotResourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -843,7 +847,7 @@ spec:
                     - name
                     type: object
                   createFromSnapshotResourceIdSelector:
-                    description: Selector for a Snapshot to populate createFromSnapshotResourceId.
+                    description: Selector for a Snapshot in netapp to populate createFromSnapshotResourceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -899,7 +903,8 @@ spec:
                           description: Resource ID of the primary volume.
                           type: string
                         remoteVolumeResourceIdRef:
-                          description: Reference to a Volume to populate remoteVolumeResourceId.
+                          description: Reference to a Volume in netapp to populate
+                            remoteVolumeResourceId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -933,7 +938,8 @@ spec:
                           - name
                           type: object
                         remoteVolumeResourceIdSelector:
-                          description: Selector for a Volume to populate remoteVolumeResourceId.
+                          description: Selector for a Volume in netapp to populate
+                            remoteVolumeResourceId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -988,7 +994,8 @@ spec:
                             to the volume.
                           type: string
                         snapshotPolicyIdRef:
-                          description: Reference to a SnapshotPolicy to populate snapshotPolicyId.
+                          description: Reference to a SnapshotPolicy in netapp to
+                            populate snapshotPolicyId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1022,7 +1029,8 @@ spec:
                           - name
                           type: object
                         snapshotPolicyIdSelector:
-                          description: Selector for a SnapshotPolicy to populate snapshotPolicyId.
+                          description: Selector for a SnapshotPolicy in netapp to
+                            populate snapshotPolicyId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/network.azure.upbound.io_applicationgateways.yaml
+++ b/package/crds/network.azure.upbound.io_applicationgateways.yaml
@@ -273,7 +273,8 @@ spec:
                             addresses for details.
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -307,7 +308,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -350,7 +352,8 @@ spec:
                           description: The ID of the Subnet.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -384,7 +387,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -656,7 +660,8 @@ spec:
                                   configuration should connect to.
                                 type: string
                               subnetIdRef:
-                                description: Reference to a Subnet to populate subnetId.
+                                description: Reference to a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   name:
                                     description: Name of the referenced object.
@@ -690,7 +695,8 @@ spec:
                                 - name
                                 type: object
                               subnetIdSelector:
-                                description: Selector for a Subnet to populate subnetId.
+                                description: Selector for a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   matchControllerRef:
                                     description: |-
@@ -1694,7 +1700,8 @@ spec:
                             addresses for details.
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1728,7 +1735,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1771,7 +1779,8 @@ spec:
                           description: The ID of the Subnet.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1805,7 +1814,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -2077,7 +2087,8 @@ spec:
                                   configuration should connect to.
                                 type: string
                               subnetIdRef:
-                                description: Reference to a Subnet to populate subnetId.
+                                description: Reference to a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   name:
                                     description: Name of the referenced object.
@@ -2111,7 +2122,8 @@ spec:
                                 - name
                                 type: object
                               subnetIdSelector:
-                                description: Selector for a Subnet to populate subnetId.
+                                description: Selector for a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   matchControllerRef:
                                     description: |-

--- a/package/crds/network.azure.upbound.io_connectionmonitors.yaml
+++ b/package/crds/network.azure.upbound.io_connectionmonitors.yaml
@@ -150,7 +150,7 @@ spec:
                       a new resource to be created.
                     type: string
                   networkWatcherIdRef:
-                    description: Reference to a Watcher to populate networkWatcherId.
+                    description: Reference to a Watcher in network to populate networkWatcherId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -184,7 +184,7 @@ spec:
                     - name
                     type: object
                   networkWatcherIdSelector:
-                    description: Selector for a Watcher to populate networkWatcherId.
+                    description: Selector for a Watcher in network to populate networkWatcherId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnsaaaarecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnsaaaarecords.yaml
@@ -252,7 +252,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -286,7 +286,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnsarecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnsarecords.yaml
@@ -252,7 +252,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -286,7 +286,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnscaarecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnscaarecords.yaml
@@ -186,7 +186,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -220,7 +220,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnscnamerecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnscnamerecords.yaml
@@ -251,7 +251,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -285,7 +285,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnsmxrecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnsmxrecords.yaml
@@ -184,7 +184,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -218,7 +218,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnsnsrecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnsnsrecords.yaml
@@ -173,7 +173,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -207,7 +207,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnsptrrecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnsptrrecords.yaml
@@ -174,7 +174,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -208,7 +208,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnssrvrecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnssrvrecords.yaml
@@ -187,7 +187,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -221,7 +221,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_dnstxtrecords.yaml
+++ b/package/crds/network.azure.upbound.io_dnstxtrecords.yaml
@@ -179,7 +179,7 @@ spec:
                       Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a DNSZone to populate zoneName.
+                    description: Reference to a DNSZone in network to populate zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -213,7 +213,7 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a DNSZone to populate zoneName.
+                    description: Selector for a DNSZone in network to populate zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_expressroutecircuitauthorizations.yaml
+++ b/package/crds/network.azure.upbound.io_expressroutecircuitauthorizations.yaml
@@ -80,7 +80,8 @@ spec:
                       to be created.
                     type: string
                   expressRouteCircuitNameRef:
-                    description: Reference to a ExpressRouteCircuit to populate expressRouteCircuitName.
+                    description: Reference to a ExpressRouteCircuit in network to
+                      populate expressRouteCircuitName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   expressRouteCircuitNameSelector:
-                    description: Selector for a ExpressRouteCircuit to populate expressRouteCircuitName.
+                    description: Selector for a ExpressRouteCircuit in network to
+                      populate expressRouteCircuitName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_expressroutecircuitconnections.yaml
+++ b/package/crds/network.azure.upbound.io_expressroutecircuitconnections.yaml
@@ -107,8 +107,8 @@ spec:
                       to be created.
                     type: string
                   peerPeeringIdRef:
-                    description: Reference to a ExpressRouteCircuitPeering to populate
-                      peerPeeringId.
+                    description: Reference to a ExpressRouteCircuitPeering in network
+                      to populate peerPeeringId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -142,8 +142,8 @@ spec:
                     - name
                     type: object
                   peerPeeringIdSelector:
-                    description: Selector for a ExpressRouteCircuitPeering to populate
-                      peerPeeringId.
+                    description: Selector for a ExpressRouteCircuitPeering in network
+                      to populate peerPeeringId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -188,8 +188,8 @@ spec:
                       this forces a new Express Route Circuit Connection to be created.
                     type: string
                   peeringIdRef:
-                    description: Reference to a ExpressRouteCircuitPeering to populate
-                      peeringId.
+                    description: Reference to a ExpressRouteCircuitPeering in network
+                      to populate peeringId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -223,8 +223,8 @@ spec:
                     - name
                     type: object
                   peeringIdSelector:
-                    description: Selector for a ExpressRouteCircuitPeering to populate
-                      peeringId.
+                    description: Selector for a ExpressRouteCircuitPeering in network
+                      to populate peeringId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -292,8 +292,8 @@ spec:
                       to be created.
                     type: string
                   peerPeeringIdRef:
-                    description: Reference to a ExpressRouteCircuitPeering to populate
-                      peerPeeringId.
+                    description: Reference to a ExpressRouteCircuitPeering in network
+                      to populate peerPeeringId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -327,8 +327,8 @@ spec:
                     - name
                     type: object
                   peerPeeringIdSelector:
-                    description: Selector for a ExpressRouteCircuitPeering to populate
-                      peerPeeringId.
+                    description: Selector for a ExpressRouteCircuitPeering in network
+                      to populate peerPeeringId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_expressroutecircuitpeerings.yaml
+++ b/package/crds/network.azure.upbound.io_expressroutecircuitpeerings.yaml
@@ -80,7 +80,8 @@ spec:
                       created.
                     type: string
                   expressRouteCircuitNameRef:
-                    description: Reference to a ExpressRouteCircuit to populate expressRouteCircuitName.
+                    description: Reference to a ExpressRouteCircuit in network to
+                      populate expressRouteCircuitName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   expressRouteCircuitNameSelector:
-                    description: Selector for a ExpressRouteCircuit to populate expressRouteCircuitName.
+                    description: Selector for a ExpressRouteCircuit in network to
+                      populate expressRouteCircuitName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_expressrouteconnections.yaml
+++ b/package/crds/network.azure.upbound.io_expressrouteconnections.yaml
@@ -87,8 +87,8 @@ spec:
                       a new resource to be created.
                     type: string
                   expressRouteCircuitPeeringIdRef:
-                    description: Reference to a ExpressRouteCircuitPeering to populate
-                      expressRouteCircuitPeeringId.
+                    description: Reference to a ExpressRouteCircuitPeering in network
+                      to populate expressRouteCircuitPeeringId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -122,8 +122,8 @@ spec:
                     - name
                     type: object
                   expressRouteCircuitPeeringIdSelector:
-                    description: Selector for a ExpressRouteCircuitPeering to populate
-                      expressRouteCircuitPeeringId.
+                    description: Selector for a ExpressRouteCircuitPeering in network
+                      to populate expressRouteCircuitPeeringId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -172,7 +172,8 @@ spec:
                       to be created.
                     type: string
                   expressRouteGatewayIdRef:
-                    description: Reference to a ExpressRouteGateway to populate expressRouteGatewayId.
+                    description: Reference to a ExpressRouteGateway in network to
+                      populate expressRouteGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -206,7 +207,8 @@ spec:
                     - name
                     type: object
                   expressRouteGatewayIdSelector:
-                    description: Selector for a ExpressRouteGateway to populate expressRouteGatewayId.
+                    description: Selector for a ExpressRouteGateway in network to
+                      populate expressRouteGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -316,8 +318,8 @@ spec:
                       a new resource to be created.
                     type: string
                   expressRouteCircuitPeeringIdRef:
-                    description: Reference to a ExpressRouteCircuitPeering to populate
-                      expressRouteCircuitPeeringId.
+                    description: Reference to a ExpressRouteCircuitPeering in network
+                      to populate expressRouteCircuitPeeringId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -351,8 +353,8 @@ spec:
                     - name
                     type: object
                   expressRouteCircuitPeeringIdSelector:
-                    description: Selector for a ExpressRouteCircuitPeering to populate
-                      expressRouteCircuitPeeringId.
+                    description: Selector for a ExpressRouteCircuitPeering in network
+                      to populate expressRouteCircuitPeeringId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_expressroutegateways.yaml
+++ b/package/crds/network.azure.upbound.io_expressroutegateways.yaml
@@ -179,7 +179,8 @@ spec:
                       to be created.
                     type: string
                   virtualHubIdRef:
-                    description: Reference to a VirtualHub to populate virtualHubId.
+                    description: Reference to a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -213,7 +214,8 @@ spec:
                     - name
                     type: object
                   virtualHubIdSelector:
-                    description: Selector for a VirtualHub to populate virtualHubId.
+                    description: Selector for a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -291,7 +293,8 @@ spec:
                       to be created.
                     type: string
                   virtualHubIdRef:
-                    description: Reference to a VirtualHub to populate virtualHubId.
+                    description: Reference to a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -325,7 +328,8 @@ spec:
                     - name
                     type: object
                   virtualHubIdSelector:
-                    description: Selector for a VirtualHub to populate virtualHubId.
+                    description: Selector for a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_firewallapplicationrulecollections.yaml
+++ b/package/crds/network.azure.upbound.io_firewallapplicationrulecollections.yaml
@@ -84,7 +84,7 @@ spec:
                       resource to be created.
                     type: string
                   azureFirewallNameRef:
-                    description: Reference to a Firewall to populate azureFirewallName.
+                    description: Reference to a Firewall in network to populate azureFirewallName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   azureFirewallNameSelector:
-                    description: Selector for a Firewall to populate azureFirewallName.
+                    description: Selector for a Firewall in network to populate azureFirewallName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_firewallnatrulecollections.yaml
+++ b/package/crds/network.azure.upbound.io_firewallnatrulecollections.yaml
@@ -84,7 +84,7 @@ spec:
                       resource to be created.
                     type: string
                   azureFirewallNameRef:
-                    description: Reference to a Firewall to populate azureFirewallName.
+                    description: Reference to a Firewall in network to populate azureFirewallName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   azureFirewallNameSelector:
-                    description: Selector for a Firewall to populate azureFirewallName.
+                    description: Selector for a Firewall in network to populate azureFirewallName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_firewallnetworkrulecollections.yaml
+++ b/package/crds/network.azure.upbound.io_firewallnetworkrulecollections.yaml
@@ -84,7 +84,7 @@ spec:
                       resource to be created.
                     type: string
                   azureFirewallNameRef:
-                    description: Reference to a Firewall to populate azureFirewallName.
+                    description: Reference to a Firewall in network to populate azureFirewallName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   azureFirewallNameSelector:
-                    description: Selector for a Firewall to populate azureFirewallName.
+                    description: Selector for a Firewall in network to populate azureFirewallName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_firewallpolicyrulecollectiongroups.yaml
+++ b/package/crds/network.azure.upbound.io_firewallpolicyrulecollectiongroups.yaml
@@ -193,7 +193,8 @@ spec:
                       a new Firewall Policy Rule Collection Group to be created.
                     type: string
                   firewallPolicyIdRef:
-                    description: Reference to a FirewallPolicy to populate firewallPolicyId.
+                    description: Reference to a FirewallPolicy in network to populate
+                      firewallPolicyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -227,7 +228,8 @@ spec:
                     - name
                     type: object
                   firewallPolicyIdSelector:
-                    description: Selector for a FirewallPolicy to populate firewallPolicyId.
+                    description: Selector for a FirewallPolicy in network to populate
+                      firewallPolicyId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_firewalls.yaml
+++ b/package/crds/network.azure.upbound.io_firewalls.yaml
@@ -99,7 +99,8 @@ spec:
                             with the firewall.
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -133,7 +134,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -178,7 +180,8 @@ spec:
                             to be created.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -212,7 +215,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -278,7 +282,8 @@ spec:
                             to be created.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -312,7 +317,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -523,7 +529,8 @@ spec:
                             with the firewall.
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -557,7 +564,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -602,7 +610,8 @@ spec:
                             to be created.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -636,7 +645,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -702,7 +712,8 @@ spec:
                             to be created.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -736,7 +747,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/network.azure.upbound.io_frontdoorrulesengines.yaml
+++ b/package/crds/network.azure.upbound.io_frontdoorrulesengines.yaml
@@ -83,7 +83,7 @@ spec:
                       forces a new resource to be created.
                     type: string
                   frontdoorNameRef:
-                    description: Reference to a FrontDoor to populate frontdoorName.
+                    description: Reference to a FrontDoor in network to populate frontdoorName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -117,7 +117,7 @@ spec:
                     - name
                     type: object
                   frontdoorNameSelector:
-                    description: Selector for a FrontDoor to populate frontdoorName.
+                    description: Selector for a FrontDoor in network to populate frontdoorName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancerbackendaddresspooladdresses.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancerbackendaddresspooladdresses.yaml
@@ -84,8 +84,8 @@ spec:
                       forces a new Backend Address Pool Address to be created.
                     type: string
                   backendAddressPoolIdRef:
-                    description: Reference to a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Reference to a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,8 +119,8 @@ spec:
                     - name
                     type: object
                   backendAddressPoolIdSelector:
-                    description: Selector for a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Selector for a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -169,7 +169,8 @@ spec:
                       For regional load balancer, user needs to specify `virtual_network_id` and `ip_address`
                     type: string
                   virtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate virtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -203,7 +204,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate virtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -271,7 +273,8 @@ spec:
                       For regional load balancer, user needs to specify `virtual_network_id` and `ip_address`
                     type: string
                   virtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate virtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -305,7 +308,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate virtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancerbackendaddresspools.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancerbackendaddresspools.yaml
@@ -80,7 +80,8 @@ spec:
                       be created.
                     type: string
                   loadbalancerIdRef:
-                    description: Reference to a LoadBalancer to populate loadbalancerId.
+                    description: Reference to a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   loadbalancerIdSelector:
-                    description: Selector for a LoadBalancer to populate loadbalancerId.
+                    description: Selector for a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancernatpools.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancernatpools.yaml
@@ -108,7 +108,8 @@ spec:
                       NAT pool. Changing this forces a new resource to be created.
                     type: string
                   loadbalancerIdRef:
-                    description: Reference to a LoadBalancer to populate loadbalancerId.
+                    description: Reference to a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -142,7 +143,8 @@ spec:
                     - name
                     type: object
                   loadbalancerIdSelector:
-                    description: Selector for a LoadBalancer to populate loadbalancerId.
+                    description: Selector for a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancernatrules.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancernatrules.yaml
@@ -197,7 +197,8 @@ spec:
                       NAT Rule. Changing this forces a new resource to be created.
                     type: string
                   loadbalancerIdRef:
-                    description: Reference to a LoadBalancer to populate loadbalancerId.
+                    description: Reference to a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -231,7 +232,8 @@ spec:
                     - name
                     type: object
                   loadbalancerIdSelector:
-                    description: Selector for a LoadBalancer to populate loadbalancerId.
+                    description: Selector for a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalanceroutboundrules.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalanceroutboundrules.yaml
@@ -83,8 +83,8 @@ spec:
                       is randomly load balanced across IPs in the backend IPs.
                     type: string
                   backendAddressPoolIdRef:
-                    description: Reference to a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Reference to a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,8 +118,8 @@ spec:
                     - name
                     type: object
                   backendAddressPoolIdSelector:
-                    description: Selector for a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Selector for a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -182,7 +182,8 @@ spec:
                       Outbound Rule. Changing this forces a new resource to be created.
                     type: string
                   loadbalancerIdRef:
-                    description: Reference to a LoadBalancer to populate loadbalancerId.
+                    description: Reference to a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -216,7 +217,8 @@ spec:
                     - name
                     type: object
                   loadbalancerIdSelector:
-                    description: Selector for a LoadBalancer to populate loadbalancerId.
+                    description: Selector for a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -282,8 +284,8 @@ spec:
                       is randomly load balanced across IPs in the backend IPs.
                     type: string
                   backendAddressPoolIdRef:
-                    description: Reference to a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Reference to a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -317,8 +319,8 @@ spec:
                     - name
                     type: object
                   backendAddressPoolIdSelector:
-                    description: Selector for a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Selector for a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancerprobes.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancerprobes.yaml
@@ -83,7 +83,8 @@ spec:
                       Probe. Changing this forces a new resource to be created.
                     type: string
                   loadbalancerIdRef:
-                    description: Reference to a LoadBalancer to populate loadbalancerId.
+                    description: Reference to a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -117,7 +118,8 @@ spec:
                     - name
                     type: object
                   loadbalancerIdSelector:
-                    description: Selector for a LoadBalancer to populate loadbalancerId.
+                    description: Selector for a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancerrules.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancerrules.yaml
@@ -128,7 +128,8 @@ spec:
                       Rule. Changing this forces a new resource to be created.
                     type: string
                   loadbalancerIdRef:
-                    description: Reference to a LoadBalancer to populate loadbalancerId.
+                    description: Reference to a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -162,7 +163,8 @@ spec:
                     - name
                     type: object
                   loadbalancerIdSelector:
-                    description: Selector for a LoadBalancer to populate loadbalancerId.
+                    description: Selector for a LoadBalancer in network to populate
+                      loadbalancerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_loadbalancers.yaml
+++ b/package/crds/network.azure.upbound.io_loadbalancers.yaml
@@ -109,7 +109,8 @@ spec:
                             be associated with the Load Balancer.
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -143,7 +144,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -192,7 +194,8 @@ spec:
                             with the IP Configuration.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -226,7 +229,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -426,7 +430,8 @@ spec:
                             be associated with the Load Balancer.
                           type: string
                         publicIpAddressIdRef:
-                          description: Reference to a PublicIP to populate publicIpAddressId.
+                          description: Reference to a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -460,7 +465,8 @@ spec:
                           - name
                           type: object
                         publicIpAddressIdSelector:
-                          description: Selector for a PublicIP to populate publicIpAddressId.
+                          description: Selector for a PublicIP in network to populate
+                            publicIpAddressId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -509,7 +515,8 @@ spec:
                             with the IP Configuration.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -543,7 +550,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/network.azure.upbound.io_managerstaticmembers.yaml
+++ b/package/crds/network.azure.upbound.io_managerstaticmembers.yaml
@@ -159,7 +159,8 @@ spec:
                       Manager Static Member to be created.
                     type: string
                   targetVirtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate targetVirtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      targetVirtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +194,8 @@ spec:
                     - name
                     type: object
                   targetVirtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate targetVirtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      targetVirtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -252,7 +254,8 @@ spec:
                       Manager Static Member to be created.
                     type: string
                   targetVirtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate targetVirtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      targetVirtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -286,7 +289,8 @@ spec:
                     - name
                     type: object
                   targetVirtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate targetVirtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      targetVirtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_natgatewaypublicipassociations.yaml
+++ b/package/crds/network.azure.upbound.io_natgatewaypublicipassociations.yaml
@@ -79,7 +79,8 @@ spec:
                       new resource to be created.
                     type: string
                   natGatewayIdRef:
-                    description: Reference to a NATGateway to populate natGatewayId.
+                    description: Reference to a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +114,8 @@ spec:
                     - name
                     type: object
                   natGatewayIdSelector:
-                    description: Selector for a NATGateway to populate natGatewayId.
+                    description: Selector for a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -158,7 +160,7 @@ spec:
                       to be created.
                     type: string
                   publicIpAddressIdRef:
-                    description: Reference to a PublicIP to populate publicIpAddressId.
+                    description: Reference to a PublicIP in network to populate publicIpAddressId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +194,7 @@ spec:
                     - name
                     type: object
                   publicIpAddressIdSelector:
-                    description: Selector for a PublicIP to populate publicIpAddressId.
+                    description: Selector for a PublicIP in network to populate publicIpAddressId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -250,7 +252,8 @@ spec:
                       new resource to be created.
                     type: string
                   natGatewayIdRef:
-                    description: Reference to a NATGateway to populate natGatewayId.
+                    description: Reference to a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -284,7 +287,8 @@ spec:
                     - name
                     type: object
                   natGatewayIdSelector:
-                    description: Selector for a NATGateway to populate natGatewayId.
+                    description: Selector for a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -329,7 +333,7 @@ spec:
                       to be created.
                     type: string
                   publicIpAddressIdRef:
-                    description: Reference to a PublicIP to populate publicIpAddressId.
+                    description: Reference to a PublicIP in network to populate publicIpAddressId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -363,7 +367,7 @@ spec:
                     - name
                     type: object
                   publicIpAddressIdSelector:
-                    description: Selector for a PublicIP to populate publicIpAddressId.
+                    description: Selector for a PublicIP in network to populate publicIpAddressId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_natgatewaypublicipprefixassociations.yaml
+++ b/package/crds/network.azure.upbound.io_natgatewaypublicipprefixassociations.yaml
@@ -79,7 +79,8 @@ spec:
                       new resource to be created.
                     type: string
                   natGatewayIdRef:
-                    description: Reference to a NATGateway to populate natGatewayId.
+                    description: Reference to a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +114,8 @@ spec:
                     - name
                     type: object
                   natGatewayIdSelector:
-                    description: Selector for a NATGateway to populate natGatewayId.
+                    description: Selector for a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -158,7 +160,8 @@ spec:
                       to be created.
                     type: string
                   publicIpPrefixIdRef:
-                    description: Reference to a PublicIPPrefix to populate publicIpPrefixId.
+                    description: Reference to a PublicIPPrefix in network to populate
+                      publicIpPrefixId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +195,8 @@ spec:
                     - name
                     type: object
                   publicIpPrefixIdSelector:
-                    description: Selector for a PublicIPPrefix to populate publicIpPrefixId.
+                    description: Selector for a PublicIPPrefix in network to populate
+                      publicIpPrefixId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -250,7 +254,8 @@ spec:
                       new resource to be created.
                     type: string
                   natGatewayIdRef:
-                    description: Reference to a NATGateway to populate natGatewayId.
+                    description: Reference to a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -284,7 +289,8 @@ spec:
                     - name
                     type: object
                   natGatewayIdSelector:
-                    description: Selector for a NATGateway to populate natGatewayId.
+                    description: Selector for a NATGateway in network to populate
+                      natGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -329,7 +335,8 @@ spec:
                       to be created.
                     type: string
                   publicIpPrefixIdRef:
-                    description: Reference to a PublicIPPrefix to populate publicIpPrefixId.
+                    description: Reference to a PublicIPPrefix in network to populate
+                      publicIpPrefixId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -363,7 +370,8 @@ spec:
                     - name
                     type: object
                   publicIpPrefixIdSelector:
-                    description: Selector for a PublicIPPrefix to populate publicIpPrefixId.
+                    description: Selector for a PublicIPPrefix in network to populate
+                      publicIpPrefixId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_networkinterfaceapplicationsecuritygroupassociations.yaml
+++ b/package/crds/network.azure.upbound.io_networkinterfaceapplicationsecuritygroupassociations.yaml
@@ -81,8 +81,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   applicationSecurityGroupIdRef:
-                    description: Reference to a ApplicationSecurityGroup to populate
-                      applicationSecurityGroupId.
+                    description: Reference to a ApplicationSecurityGroup in network
+                      to populate applicationSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,8 +116,8 @@ spec:
                     - name
                     type: object
                   applicationSecurityGroupIdSelector:
-                    description: Selector for a ApplicationSecurityGroup to populate
-                      applicationSecurityGroupId.
+                    description: Selector for a ApplicationSecurityGroup in network
+                      to populate applicationSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -161,7 +161,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -195,7 +196,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -254,8 +256,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   applicationSecurityGroupIdRef:
-                    description: Reference to a ApplicationSecurityGroup to populate
-                      applicationSecurityGroupId.
+                    description: Reference to a ApplicationSecurityGroup in network
+                      to populate applicationSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -289,8 +291,8 @@ spec:
                     - name
                     type: object
                   applicationSecurityGroupIdSelector:
-                    description: Selector for a ApplicationSecurityGroup to populate
-                      applicationSecurityGroupId.
+                    description: Selector for a ApplicationSecurityGroup in network
+                      to populate applicationSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -334,7 +336,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -368,7 +371,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_networkinterfacebackendaddresspoolassociations.yaml
+++ b/package/crds/network.azure.upbound.io_networkinterfacebackendaddresspoolassociations.yaml
@@ -81,8 +81,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   backendAddressPoolIdRef:
-                    description: Reference to a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Reference to a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,8 +116,8 @@ spec:
                     - name
                     type: object
                   backendAddressPoolIdSelector:
-                    description: Selector for a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Selector for a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -166,7 +166,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -200,7 +201,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -259,8 +261,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   backendAddressPoolIdRef:
-                    description: Reference to a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Reference to a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -294,8 +296,8 @@ spec:
                     - name
                     type: object
                   backendAddressPoolIdSelector:
-                    description: Selector for a LoadBalancerBackendAddressPool to
-                      populate backendAddressPoolId.
+                    description: Selector for a LoadBalancerBackendAddressPool in
+                      network to populate backendAddressPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -344,7 +346,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -378,7 +381,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_networkinterfacenatruleassociations.yaml
+++ b/package/crds/network.azure.upbound.io_networkinterfacenatruleassociations.yaml
@@ -86,7 +86,8 @@ spec:
                       a new resource to be created.
                     type: string
                   natRuleIdRef:
-                    description: Reference to a LoadBalancerNatRule to populate natRuleId.
+                    description: Reference to a LoadBalancerNatRule in network to
+                      populate natRuleId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -120,7 +121,8 @@ spec:
                     - name
                     type: object
                   natRuleIdSelector:
-                    description: Selector for a LoadBalancerNatRule to populate natRuleId.
+                    description: Selector for a LoadBalancerNatRule in network to
+                      populate natRuleId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -164,7 +166,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -198,7 +201,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -262,7 +266,8 @@ spec:
                       a new resource to be created.
                     type: string
                   natRuleIdRef:
-                    description: Reference to a LoadBalancerNatRule to populate natRuleId.
+                    description: Reference to a LoadBalancerNatRule in network to
+                      populate natRuleId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -296,7 +301,8 @@ spec:
                     - name
                     type: object
                   natRuleIdSelector:
-                    description: Selector for a LoadBalancerNatRule to populate natRuleId.
+                    description: Selector for a LoadBalancerNatRule in network to
+                      populate natRuleId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -340,7 +346,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -374,7 +381,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_networkinterfacesecuritygroupassociations.yaml
+++ b/package/crds/network.azure.upbound.io_networkinterfacesecuritygroupassociations.yaml
@@ -80,7 +80,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -159,7 +161,8 @@ spec:
                       new resource to be created.
                     type: string
                   networkSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupId.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +196,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupId.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -251,7 +255,8 @@ spec:
                       a new resource to be created.
                     type: string
                   networkInterfaceIdRef:
-                    description: Reference to a NetworkInterface to populate networkInterfaceId.
+                    description: Reference to a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -285,7 +290,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceIdSelector:
-                    description: Selector for a NetworkInterface to populate networkInterfaceId.
+                    description: Selector for a NetworkInterface in network to populate
+                      networkInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -330,7 +336,8 @@ spec:
                       new resource to be created.
                     type: string
                   networkSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupId.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -364,7 +371,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupId.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_packetcaptures.yaml
+++ b/package/crds/network.azure.upbound.io_packetcaptures.yaml
@@ -135,7 +135,7 @@ spec:
                       a new resource to be created.
                     type: string
                   networkWatcherNameRef:
-                    description: Reference to a Watcher to populate networkWatcherName.
+                    description: Reference to a Watcher in network to populate networkWatcherName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -169,7 +169,7 @@ spec:
                     - name
                     type: object
                   networkWatcherNameSelector:
-                    description: Selector for a Watcher to populate networkWatcherName.
+                    description: Selector for a Watcher in network to populate networkWatcherName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_pointtositevpngateways.yaml
+++ b/package/crds/network.azure.upbound.io_pointtositevpngateways.yaml
@@ -256,7 +256,8 @@ spec:
                       to be created.
                     type: string
                   virtualHubIdRef:
-                    description: Reference to a VirtualHub to populate virtualHubId.
+                    description: Reference to a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -290,7 +291,8 @@ spec:
                     - name
                     type: object
                   virtualHubIdSelector:
-                    description: Selector for a VirtualHub to populate virtualHubId.
+                    description: Selector for a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -335,8 +337,8 @@ spec:
                       new resource to be created.
                     type: string
                   vpnServerConfigurationIdRef:
-                    description: Reference to a VPNServerConfiguration to populate
-                      vpnServerConfigurationId.
+                    description: Reference to a VPNServerConfiguration in network
+                      to populate vpnServerConfigurationId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -370,8 +372,8 @@ spec:
                     - name
                     type: object
                   vpnServerConfigurationIdSelector:
-                    description: Selector for a VPNServerConfiguration to populate
-                      vpnServerConfigurationId.
+                    description: Selector for a VPNServerConfiguration in network
+                      to populate vpnServerConfigurationId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -526,7 +528,8 @@ spec:
                       to be created.
                     type: string
                   virtualHubIdRef:
-                    description: Reference to a VirtualHub to populate virtualHubId.
+                    description: Reference to a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -560,7 +563,8 @@ spec:
                     - name
                     type: object
                   virtualHubIdSelector:
-                    description: Selector for a VirtualHub to populate virtualHubId.
+                    description: Selector for a VirtualHub in network to populate
+                      virtualHubId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -605,8 +609,8 @@ spec:
                       new resource to be created.
                     type: string
                   vpnServerConfigurationIdRef:
-                    description: Reference to a VPNServerConfiguration to populate
-                      vpnServerConfigurationId.
+                    description: Reference to a VPNServerConfiguration in network
+                      to populate vpnServerConfigurationId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -640,8 +644,8 @@ spec:
                     - name
                     type: object
                   vpnServerConfigurationIdSelector:
-                    description: Selector for a VPNServerConfiguration to populate
-                      vpnServerConfigurationId.
+                    description: Selector for a VPNServerConfiguration in network
+                      to populate vpnServerConfigurationId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednsaaaarecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednsaaaarecords.yaml
@@ -173,7 +173,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -207,7 +208,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednsarecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednsarecords.yaml
@@ -173,7 +173,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -207,7 +208,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednscnamerecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednscnamerecords.yaml
@@ -171,7 +171,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -205,7 +206,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednsmxrecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednsmxrecords.yaml
@@ -180,7 +180,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -214,7 +215,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednsptrrecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednsptrrecords.yaml
@@ -173,7 +173,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -207,7 +208,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednssrvrecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednssrvrecords.yaml
@@ -185,7 +185,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -219,7 +220,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednstxtrecords.yaml
+++ b/package/crds/network.azure.upbound.io_privatednstxtrecords.yaml
@@ -177,7 +177,8 @@ spec:
                       exists. Changing this forces a new resource to be created.
                     type: string
                   zoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate zoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -211,7 +212,8 @@ spec:
                     - name
                     type: object
                   zoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate zoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      zoneName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privatednszonevirtualnetworklinks.yaml
+++ b/package/crds/network.azure.upbound.io_privatednszonevirtualnetworklinks.yaml
@@ -79,7 +79,8 @@ spec:
                       dot). Changing this forces a new resource to be created.
                     type: string
                   privateDnsZoneNameRef:
-                    description: Reference to a PrivateDNSZone to populate privateDnsZoneName.
+                    description: Reference to a PrivateDNSZone in network to populate
+                      privateDnsZoneName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +114,8 @@ spec:
                     - name
                     type: object
                   privateDnsZoneNameSelector:
-                    description: Selector for a PrivateDNSZone to populate privateDnsZoneName.
+                    description: Selector for a PrivateDNSZone in network to populate
+                      privateDnsZoneName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -248,7 +250,8 @@ spec:
                       to the DNS Zone. Changing this forces a new resource to be created.
                     type: string
                   virtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate virtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -282,7 +285,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate virtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -351,7 +355,8 @@ spec:
                       to the DNS Zone. Changing this forces a new resource to be created.
                     type: string
                   virtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate virtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -385,7 +390,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate virtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      virtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_privateendpoints.yaml
+++ b/package/crds/network.azure.upbound.io_privateendpoints.yaml
@@ -124,7 +124,8 @@ spec:
                             type: string
                           type: array
                         privateDnsZoneIdsRefs:
-                          description: References to PrivateDNSZone to populate privateDnsZoneIds.
+                          description: References to PrivateDNSZone in network to
+                            populate privateDnsZoneIds.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -161,8 +162,8 @@ spec:
                             type: object
                           type: array
                         privateDnsZoneIdsSelector:
-                          description: Selector for a list of PrivateDNSZone to populate
-                            privateDnsZoneIds.
+                          description: Selector for a list of PrivateDNSZone in network
+                            to populate privateDnsZoneIds.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -481,7 +482,8 @@ spec:
                             type: string
                           type: array
                         privateDnsZoneIdsRefs:
-                          description: References to PrivateDNSZone to populate privateDnsZoneIds.
+                          description: References to PrivateDNSZone in network to
+                            populate privateDnsZoneIds.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -518,8 +520,8 @@ spec:
                             type: object
                           type: array
                         privateDnsZoneIdsSelector:
-                          description: Selector for a list of PrivateDNSZone to populate
-                            privateDnsZoneIds.
+                          description: Selector for a list of PrivateDNSZone in network
+                            to populate privateDnsZoneIds.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/network.azure.upbound.io_privatelinkservices.yaml
+++ b/package/crds/network.azure.upbound.io_privatelinkservices.yaml
@@ -131,7 +131,8 @@ spec:
                             be used for the Private Link Service.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -165,7 +166,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -372,7 +374,8 @@ spec:
                             be used for the Private Link Service.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -406,7 +409,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/network.azure.upbound.io_profiles.yaml
+++ b/package/crds/network.azure.upbound.io_profiles.yaml
@@ -92,7 +92,8 @@ spec:
                                   the IP Configuration.
                                 type: string
                               subnetIdRef:
-                                description: Reference to a Subnet to populate subnetId.
+                                description: Reference to a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   name:
                                     description: Name of the referenced object.
@@ -126,7 +127,8 @@ spec:
                                 - name
                                 type: object
                               subnetIdSelector:
-                                description: Selector for a Subnet to populate subnetId.
+                                description: Selector for a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   matchControllerRef:
                                     description: |-
@@ -295,7 +297,8 @@ spec:
                                   the IP Configuration.
                                 type: string
                               subnetIdRef:
-                                description: Reference to a Subnet to populate subnetId.
+                                description: Reference to a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   name:
                                     description: Name of the referenced object.
@@ -329,7 +332,8 @@ spec:
                                 - name
                                 type: object
                               subnetIdSelector:
-                                description: Selector for a Subnet to populate subnetId.
+                                description: Selector for a Subnet in network to populate
+                                  subnetId.
                                 properties:
                                   matchControllerRef:
                                     description: |-

--- a/package/crds/network.azure.upbound.io_securityrules.yaml
+++ b/package/crds/network.azure.upbound.io_securityrules.yaml
@@ -128,7 +128,8 @@ spec:
                       be created.
                     type: string
                   networkSecurityGroupNameRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupName.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -162,7 +163,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupNameSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupName.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_subnetnatgatewayassociations.yaml
+++ b/package/crds/network.azure.upbound.io_subnetnatgatewayassociations.yaml
@@ -159,7 +159,7 @@ spec:
                       resource to be created.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in network to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +193,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in network to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -331,7 +331,7 @@ spec:
                       resource to be created.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in network to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -365,7 +365,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in network to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_subnetnetworksecuritygroupassociations.yaml
+++ b/package/crds/network.azure.upbound.io_subnetnetworksecuritygroupassociations.yaml
@@ -80,7 +80,8 @@ spec:
                       to be created.
                     type: string
                   networkSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupId.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupId.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -158,7 +160,7 @@ spec:
                       resource to be created.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in network to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +194,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in network to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -251,7 +253,8 @@ spec:
                       to be created.
                     type: string
                   networkSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupId.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -285,7 +288,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupId.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -329,7 +333,7 @@ spec:
                       resource to be created.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in network to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -363,7 +367,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in network to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_subnetroutetableassociations.yaml
+++ b/package/crds/network.azure.upbound.io_subnetroutetableassociations.yaml
@@ -79,7 +79,8 @@ spec:
                       with the Subnet. Changing this forces a new resource to be created.
                     type: string
                   routeTableIdRef:
-                    description: Reference to a RouteTable to populate routeTableId.
+                    description: Reference to a RouteTable in network to populate
+                      routeTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +114,8 @@ spec:
                     - name
                     type: object
                   routeTableIdSelector:
-                    description: Selector for a RouteTable to populate routeTableId.
+                    description: Selector for a RouteTable in network to populate
+                      routeTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -157,7 +159,7 @@ spec:
                       resource to be created.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in network to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -191,7 +193,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in network to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -249,7 +251,8 @@ spec:
                       with the Subnet. Changing this forces a new resource to be created.
                     type: string
                   routeTableIdRef:
-                    description: Reference to a RouteTable to populate routeTableId.
+                    description: Reference to a RouteTable in network to populate
+                      routeTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -283,7 +286,8 @@ spec:
                     - name
                     type: object
                   routeTableIdSelector:
-                    description: Selector for a RouteTable to populate routeTableId.
+                    description: Selector for a RouteTable in network to populate
+                      routeTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -327,7 +331,7 @@ spec:
                       resource to be created.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in network to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -361,7 +365,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in network to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_subnets.yaml
+++ b/package/crds/network.azure.upbound.io_subnets.yaml
@@ -260,7 +260,8 @@ spec:
                       the subnet. Changing this forces a new resource to be created.
                     type: string
                   virtualNetworkNameRef:
-                    description: Reference to a VirtualNetwork to populate virtualNetworkName.
+                    description: Reference to a VirtualNetwork in network to populate
+                      virtualNetworkName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -294,7 +295,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkNameSelector:
-                    description: Selector for a VirtualNetwork to populate virtualNetworkName.
+                    description: Selector for a VirtualNetwork in network to populate
+                      virtualNetworkName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_virtualhubs.yaml
+++ b/package/crds/network.azure.upbound.io_virtualhubs.yaml
@@ -203,7 +203,8 @@ spec:
                       be created.
                     type: string
                   virtualWanIdRef:
-                    description: Reference to a VirtualWAN to populate virtualWanId.
+                    description: Reference to a VirtualWAN in network to populate
+                      virtualWanId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -237,7 +238,8 @@ spec:
                     - name
                     type: object
                   virtualWanIdSelector:
-                    description: Selector for a VirtualWAN to populate virtualWanId.
+                    description: Selector for a VirtualWAN in network to populate
+                      virtualWanId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -339,7 +341,8 @@ spec:
                       be created.
                     type: string
                   virtualWanIdRef:
-                    description: Reference to a VirtualWAN to populate virtualWanId.
+                    description: Reference to a VirtualWAN in network to populate
+                      virtualWanId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -373,7 +376,8 @@ spec:
                     - name
                     type: object
                   virtualWanIdSelector:
-                    description: Selector for a VirtualWAN to populate virtualWanId.
+                    description: Selector for a VirtualWAN in network to populate
+                      virtualWanId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_virtualnetworkgatewayconnections.yaml
+++ b/package/crds/network.azure.upbound.io_virtualnetworkgatewayconnections.yaml
@@ -290,8 +290,8 @@ spec:
                       subscription. Changing this forces a new resource to be created.
                     type: string
                   peerVirtualNetworkGatewayIdRef:
-                    description: Reference to a VirtualNetworkGateway to populate
-                      peerVirtualNetworkGatewayId.
+                    description: Reference to a VirtualNetworkGateway in network to
+                      populate peerVirtualNetworkGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -325,8 +325,8 @@ spec:
                     - name
                     type: object
                   peerVirtualNetworkGatewayIdSelector:
-                    description: Selector for a VirtualNetworkGateway to populate
-                      peerVirtualNetworkGatewayId.
+                    description: Selector for a VirtualNetworkGateway in network to
+                      populate peerVirtualNetworkGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -509,8 +509,8 @@ spec:
                       to be created.
                     type: string
                   virtualNetworkGatewayIdRef:
-                    description: Reference to a VirtualNetworkGateway to populate
-                      virtualNetworkGatewayId.
+                    description: Reference to a VirtualNetworkGateway in network to
+                      populate virtualNetworkGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -544,8 +544,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkGatewayIdSelector:
-                    description: Selector for a VirtualNetworkGateway to populate
-                      virtualNetworkGatewayId.
+                    description: Selector for a VirtualNetworkGateway in network to
+                      populate virtualNetworkGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -795,8 +795,8 @@ spec:
                       subscription. Changing this forces a new resource to be created.
                     type: string
                   peerVirtualNetworkGatewayIdRef:
-                    description: Reference to a VirtualNetworkGateway to populate
-                      peerVirtualNetworkGatewayId.
+                    description: Reference to a VirtualNetworkGateway in network to
+                      populate peerVirtualNetworkGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -830,8 +830,8 @@ spec:
                     - name
                     type: object
                   peerVirtualNetworkGatewayIdSelector:
-                    description: Selector for a VirtualNetworkGateway to populate
-                      peerVirtualNetworkGatewayId.
+                    description: Selector for a VirtualNetworkGateway in network to
+                      populate peerVirtualNetworkGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -916,8 +916,8 @@ spec:
                       to be created.
                     type: string
                   virtualNetworkGatewayIdRef:
-                    description: Reference to a VirtualNetworkGateway to populate
-                      virtualNetworkGatewayId.
+                    description: Reference to a VirtualNetworkGateway in network to
+                      populate virtualNetworkGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -951,8 +951,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkGatewayIdSelector:
-                    description: Selector for a VirtualNetworkGateway to populate
-                      virtualNetworkGatewayId.
+                    description: Selector for a VirtualNetworkGateway in network to
+                      populate virtualNetworkGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_virtualnetworkgateways.yaml
+++ b/package/crds/network.azure.upbound.io_virtualnetworkgateways.yaml
@@ -267,7 +267,8 @@ spec:
                             single Virtual Network Gateway.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -301,7 +302,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -905,7 +907,8 @@ spec:
                             single Virtual Network Gateway.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in network to populate
+                            subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -939,7 +942,8 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in network to populate
+                            subnetId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/network.azure.upbound.io_virtualnetworkpeerings.yaml
+++ b/package/crds/network.azure.upbound.io_virtualnetworkpeerings.yaml
@@ -91,7 +91,8 @@ spec:
                       network. Changing this forces a new resource to be created.
                     type: string
                   remoteVirtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate remoteVirtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      remoteVirtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -125,7 +126,8 @@ spec:
                     - name
                     type: object
                   remoteVirtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate remoteVirtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      remoteVirtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -267,7 +269,8 @@ spec:
                       a new resource to be created.
                     type: string
                   virtualNetworkNameRef:
-                    description: Reference to a VirtualNetwork to populate virtualNetworkName.
+                    description: Reference to a VirtualNetwork in network to populate
+                      virtualNetworkName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -301,7 +304,8 @@ spec:
                     - name
                     type: object
                   virtualNetworkNameSelector:
-                    description: Selector for a VirtualNetwork to populate virtualNetworkName.
+                    description: Selector for a VirtualNetwork in network to populate
+                      virtualNetworkName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -371,7 +375,8 @@ spec:
                       network. Changing this forces a new resource to be created.
                     type: string
                   remoteVirtualNetworkIdRef:
-                    description: Reference to a VirtualNetwork to populate remoteVirtualNetworkId.
+                    description: Reference to a VirtualNetwork in network to populate
+                      remoteVirtualNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -405,7 +410,8 @@ spec:
                     - name
                     type: object
                   remoteVirtualNetworkIdSelector:
-                    description: Selector for a VirtualNetwork to populate remoteVirtualNetworkId.
+                    description: Selector for a VirtualNetwork in network to populate
+                      remoteVirtualNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/network.azure.upbound.io_watcherflowlogs.yaml
+++ b/package/crds/network.azure.upbound.io_watcherflowlogs.yaml
@@ -87,7 +87,8 @@ spec:
                       be created.
                     type: string
                   networkSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupId.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +122,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupId.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -165,7 +167,7 @@ spec:
                       a new resource to be created.
                     type: string
                   networkWatcherNameRef:
-                    description: Reference to a Watcher to populate networkWatcherName.
+                    description: Reference to a Watcher in network to populate networkWatcherName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -199,7 +201,7 @@ spec:
                     - name
                     type: object
                   networkWatcherNameSelector:
-                    description: Selector for a Watcher to populate networkWatcherName.
+                    description: Selector for a Watcher in network to populate networkWatcherName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -622,7 +624,8 @@ spec:
                       be created.
                     type: string
                   networkSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate networkSecurityGroupId.
+                    description: Reference to a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -656,7 +659,8 @@ spec:
                     - name
                     type: object
                   networkSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate networkSecurityGroupId.
+                    description: Selector for a SecurityGroup in network to populate
+                      networkSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqldatabases.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqldatabases.yaml
@@ -303,7 +303,7 @@ spec:
                       database. Changing this forces a new resource to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a MSSQLServer to populate serverId.
+                    description: Reference to a MSSQLServer in sql to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -337,7 +337,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a MSSQLServer to populate serverId.
+                    description: Selector for a MSSQLServer in sql to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqldatabasevulnerabilityassessmentrulebaselines.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqldatabasevulnerabilityassessmentrulebaselines.yaml
@@ -98,7 +98,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   databaseNameRef:
-                    description: Reference to a MSSQLDatabase to populate databaseName.
+                    description: Reference to a MSSQLDatabase in sql to populate databaseName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -132,7 +132,7 @@ spec:
                     - name
                     type: object
                   databaseNameSelector:
-                    description: Selector for a MSSQLDatabase to populate databaseName.
+                    description: Selector for a MSSQLDatabase in sql to populate databaseName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -292,7 +292,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   databaseNameRef:
-                    description: Reference to a MSSQLDatabase to populate databaseName.
+                    description: Reference to a MSSQLDatabase in sql to populate databaseName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -326,7 +326,7 @@ spec:
                     - name
                     type: object
                   databaseNameSelector:
-                    description: Selector for a MSSQLDatabase to populate databaseName.
+                    description: Selector for a MSSQLDatabase in sql to populate databaseName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlelasticpools.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlelasticpools.yaml
@@ -215,7 +215,7 @@ spec:
                       elastic pool. Changing this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a MSSQLServer to populate serverName.
+                    description: Reference to a MSSQLServer in sql to populate serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -249,7 +249,7 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a MSSQLServer to populate serverName.
+                    description: Selector for a MSSQLServer in sql to populate serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlfailovergroups.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlfailovergroups.yaml
@@ -81,7 +81,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   databasesRefs:
-                    description: References to MSSQLDatabase to populate databases.
+                    description: References to MSSQLDatabase in sql to populate databases.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -118,7 +118,7 @@ spec:
                       type: object
                     type: array
                   databasesSelector:
-                    description: Selector for a list of MSSQLDatabase to populate
+                    description: Selector for a list of MSSQLDatabase in sql to populate
                       databases.
                     properties:
                       matchControllerRef:
@@ -167,7 +167,8 @@ spec:
                             the failover group.
                           type: string
                         idRef:
-                          description: Reference to a MSSQLServer to populate id.
+                          description: Reference to a MSSQLServer in sql to populate
+                            id.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -201,7 +202,8 @@ spec:
                           - name
                           type: object
                         idSelector:
-                          description: Selector for a MSSQLServer to populate id.
+                          description: Selector for a MSSQLServer in sql to populate
+                            id.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -269,7 +271,7 @@ spec:
                       created.
                     type: string
                   serverIdRef:
-                    description: Reference to a MSSQLServer to populate serverId.
+                    description: Reference to a MSSQLServer in sql to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -303,7 +305,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a MSSQLServer to populate serverId.
+                    description: Selector for a MSSQLServer in sql to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -370,7 +372,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   databasesRefs:
-                    description: References to MSSQLDatabase to populate databases.
+                    description: References to MSSQLDatabase in sql to populate databases.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -407,7 +409,7 @@ spec:
                       type: object
                     type: array
                   databasesSelector:
-                    description: Selector for a list of MSSQLDatabase to populate
+                    description: Selector for a list of MSSQLDatabase in sql to populate
                       databases.
                     properties:
                       matchControllerRef:
@@ -456,7 +458,8 @@ spec:
                             the failover group.
                           type: string
                         idRef:
-                          description: Reference to a MSSQLServer to populate id.
+                          description: Reference to a MSSQLServer in sql to populate
+                            id.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -490,7 +493,8 @@ spec:
                           - name
                           type: object
                         idSelector:
-                          description: Selector for a MSSQLServer to populate id.
+                          description: Selector for a MSSQLServer in sql to populate
+                            id.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlmanageddatabases.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlmanageddatabases.yaml
@@ -108,7 +108,8 @@ spec:
                       resource to be created.
                     type: string
                   managedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -142,7 +143,8 @@ spec:
                     - name
                     type: object
                   managedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlmanagedinstanceactivedirectoryadministrators.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlmanagedinstanceactivedirectoryadministrators.yaml
@@ -89,7 +89,8 @@ spec:
                       to be created.
                     type: string
                   managedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -123,7 +124,8 @@ spec:
                     - name
                     type: object
                   managedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlmanagedinstancefailovergroups.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlmanagedinstancefailovergroups.yaml
@@ -85,7 +85,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   managedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,7 +120,8 @@ spec:
                     - name
                     type: object
                   managedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -164,7 +166,8 @@ spec:
                       created.
                     type: string
                   partnerManagedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate partnerManagedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      partnerManagedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -198,7 +201,8 @@ spec:
                     - name
                     type: object
                   partnerManagedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate partnerManagedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      partnerManagedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -278,7 +282,8 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   managedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -312,7 +317,8 @@ spec:
                     - name
                     type: object
                   managedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -357,7 +363,8 @@ spec:
                       created.
                     type: string
                   partnerManagedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate partnerManagedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      partnerManagedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -391,7 +398,8 @@ spec:
                     - name
                     type: object
                   partnerManagedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate partnerManagedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      partnerManagedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlmanagedinstances.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlmanagedinstances.yaml
@@ -106,7 +106,8 @@ spec:
                       Setting this after creation forces a new resource to be created.
                     type: string
                   dnsZonePartnerIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate dnsZonePartnerId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      dnsZonePartnerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -140,7 +141,8 @@ spec:
                     - name
                     type: object
                   dnsZonePartnerIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate dnsZonePartnerId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      dnsZonePartnerId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -450,7 +452,8 @@ spec:
                       Setting this after creation forces a new resource to be created.
                     type: string
                   dnsZonePartnerIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate dnsZonePartnerId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      dnsZonePartnerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -484,7 +487,8 @@ spec:
                     - name
                     type: object
                   dnsZonePartnerIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate dnsZonePartnerId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      dnsZonePartnerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlmanagedinstancevulnerabilityassessments.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlmanagedinstancevulnerabilityassessments.yaml
@@ -80,7 +80,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   managedInstanceIdRef:
-                    description: Reference to a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Reference to a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   managedInstanceIdSelector:
-                    description: Selector for a MSSQLManagedInstance to populate managedInstanceId.
+                    description: Selector for a MSSQLManagedInstance in sql to populate
+                      managedInstanceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqloutboundfirewallrules.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqloutboundfirewallrules.yaml
@@ -80,7 +80,7 @@ spec:
                       to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a MSSQLServer to populate serverId.
+                    description: Reference to a MSSQLServer in sql to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +114,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a MSSQLServer to populate serverId.
+                    description: Selector for a MSSQLServer in sql to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlserverdnsaliases.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlserverdnsaliases.yaml
@@ -78,7 +78,7 @@ spec:
                       a new MSSQL Server DNS Alias to be created.
                     type: string
                   mssqlServerIdRef:
-                    description: Reference to a MSSQLServer to populate mssqlServerId.
+                    description: Reference to a MSSQLServer in sql to populate mssqlServerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   mssqlServerIdSelector:
-                    description: Selector for a MSSQLServer to populate mssqlServerId.
+                    description: Selector for a MSSQLServer in sql to populate mssqlServerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlserversecurityalertpolicies.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlserversecurityalertpolicies.yaml
@@ -182,7 +182,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverNameRef:
-                    description: Reference to a MSSQLServer to populate serverName.
+                    description: Reference to a MSSQLServer in sql to populate serverName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -216,7 +216,7 @@ spec:
                     - name
                     type: object
                   serverNameSelector:
-                    description: Selector for a MSSQLServer to populate serverName.
+                    description: Selector for a MSSQLServer in sql to populate serverName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlservertransparentdataencryptions.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlservertransparentdataencryptions.yaml
@@ -165,7 +165,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a MSSQLServer to populate serverId.
+                    description: Reference to a MSSQLServer in sql to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -199,7 +199,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a MSSQLServer to populate serverId.
+                    description: Selector for a MSSQLServer in sql to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/sql.azure.upbound.io_mssqlvirtualnetworkrules.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqlvirtualnetworkrules.yaml
@@ -85,7 +85,7 @@ spec:
                       new resource to be created.
                     type: string
                   serverIdRef:
-                    description: Reference to a MSSQLServer to populate serverId.
+                    description: Reference to a MSSQLServer in sql to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -119,7 +119,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a MSSQLServer to populate serverId.
+                    description: Selector for a MSSQLServer in sql to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/storage.azure.upbound.io_blobs.yaml
+++ b/package/crds/storage.azure.upbound.io_blobs.yaml
@@ -131,7 +131,7 @@ spec:
                       be created.
                     type: string
                   storageAccountNameRef:
-                    description: Reference to a Account to populate storageAccountName.
+                    description: Reference to a Account in storage to populate storageAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -165,7 +165,7 @@ spec:
                     - name
                     type: object
                   storageAccountNameSelector:
-                    description: Selector for a Account to populate storageAccountName.
+                    description: Selector for a Account in storage to populate storageAccountName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -210,7 +210,7 @@ spec:
                       created.
                     type: string
                   storageContainerNameRef:
-                    description: Reference to a Container to populate storageContainerName.
+                    description: Reference to a Container in storage to populate storageContainerName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -244,7 +244,7 @@ spec:
                     - name
                     type: object
                   storageContainerNameSelector:
-                    description: Selector for a Container to populate storageContainerName.
+                    description: Selector for a Container in storage to populate storageContainerName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/storage.azure.upbound.io_containers.yaml
+++ b/package/crds/storage.azure.upbound.io_containers.yaml
@@ -90,7 +90,7 @@ spec:
                       created.
                     type: string
                   storageAccountNameRef:
-                    description: Reference to a Account to populate storageAccountName.
+                    description: Reference to a Account in storage to populate storageAccountName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -124,7 +124,7 @@ spec:
                     - name
                     type: object
                   storageAccountNameSelector:
-                    description: Selector for a Account to populate storageAccountName.
+                    description: Selector for a Account in storage to populate storageAccountName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/storage.azure.upbound.io_datalakegen2filesystems.yaml
+++ b/package/crds/storage.azure.upbound.io_datalakegen2filesystems.yaml
@@ -121,7 +121,7 @@ spec:
                       a new resource to be created.
                     type: string
                   storageAccountIdRef:
-                    description: Reference to a Account to populate storageAccountId.
+                    description: Reference to a Account in storage to populate storageAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -155,7 +155,7 @@ spec:
                     - name
                     type: object
                   storageAccountIdSelector:
-                    description: Selector for a Account to populate storageAccountId.
+                    description: Selector for a Account in storage to populate storageAccountId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -256,7 +256,7 @@ spec:
                       a new resource to be created.
                     type: string
                   storageAccountIdRef:
-                    description: Reference to a Account to populate storageAccountId.
+                    description: Reference to a Account in storage to populate storageAccountId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -290,7 +290,7 @@ spec:
                     - name
                     type: object
                   storageAccountIdSelector:
-                    description: Selector for a Account to populate storageAccountId.
+                    description: Selector for a Account in storage to populate storageAccountId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_functionjavascriptudas.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_functionjavascriptudas.yaml
@@ -109,7 +109,8 @@ spec:
                       resource to be created.
                     type: string
                   streamAnalyticsJobIdRef:
-                    description: Reference to a Job to populate streamAnalyticsJobId.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -143,7 +144,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobIdSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobId.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -231,7 +233,8 @@ spec:
                       resource to be created.
                     type: string
                   streamAnalyticsJobIdRef:
-                    description: Reference to a Job to populate streamAnalyticsJobId.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -265,7 +268,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobIdSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobId.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_outputblobs.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_outputblobs.yaml
@@ -382,7 +382,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -416,7 +417,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -684,7 +686,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -718,7 +721,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_outputmssqls.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_outputmssqls.yaml
@@ -276,7 +276,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -310,7 +311,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -630,7 +632,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -664,7 +667,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_outputpowerbis.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_outputpowerbis.yaml
@@ -89,7 +89,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobIdRef:
-                    description: Reference to a Job to populate streamAnalyticsJobId.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -123,7 +124,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobIdSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobId.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -204,7 +206,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobIdRef:
-                    description: Reference to a Job to populate streamAnalyticsJobId.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -238,7 +241,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobIdSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobId.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_outputservicebusqueues.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_outputservicebusqueues.yaml
@@ -377,7 +377,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -411,7 +412,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -758,7 +760,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -792,7 +795,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_outputservicebustopics.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_outputservicebustopics.yaml
@@ -300,7 +300,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -334,7 +335,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -681,7 +683,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -715,7 +718,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_outputsynapses.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_outputsynapses.yaml
@@ -184,7 +184,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -218,7 +219,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_referenceinputblobs.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_referenceinputblobs.yaml
@@ -370,7 +370,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -404,7 +405,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -740,7 +742,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -774,7 +777,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_streaminputblobs.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_streaminputblobs.yaml
@@ -364,7 +364,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -398,7 +399,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -728,7 +730,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -762,7 +765,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_streaminputeventhubs.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_streaminputeventhubs.yaml
@@ -452,7 +452,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -486,7 +487,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -900,7 +902,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -934,7 +937,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/streamanalytics.azure.upbound.io_streaminputiothubs.yaml
+++ b/package/crds/streamanalytics.azure.upbound.io_streaminputiothubs.yaml
@@ -367,7 +367,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -401,7 +402,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -730,7 +732,8 @@ spec:
                       forces a new resource to be created.
                     type: string
                   streamAnalyticsJobNameRef:
-                    description: Reference to a Job to populate streamAnalyticsJobName.
+                    description: Reference to a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -764,7 +767,8 @@ spec:
                     - name
                     type: object
                   streamAnalyticsJobNameSelector:
-                    description: Selector for a Job to populate streamAnalyticsJobName.
+                    description: Selector for a Job in streamanalytics to populate
+                      streamAnalyticsJobName.
                     properties:
                       matchControllerRef:
                         description: |-


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR replaces usages of upjet's `config.Reference.Type` API with `config.Reference.TerraformName`. In https://github.com/crossplane/upjet/pull/400, we are deprecating the `config.Reference.Type` API in favor of `config.Reference.TerraformName`. We had introduced `config.Reference.TerraformName` in https://github.com/crossplane/upjet/pull/12 and it's a more stable and less error prone API compared to `config.Reference.Type` because it automatically accounts for the configuration changes affecting the cross-resource reference target's kind name, group or version. We've already been discouraging the `config.Reference.Type` in favor of `config.Reference.TerraformName` since it's been introduced.

This PR is a precursor for #733, in which we will start generating the `v1beta2` APIs for certain resources (those with singleton lists in their Terraform schemas). When the `config.Reference.Type` is used to define the reference target, the API version can be omitted for the targets in the same group and version. In those cases, if the referencing resource has been generated at `v1beta2` whereas the reference target lacks that version, the generated resolver is not valid. Using `config.Reference.TerraformName` instead will help us in future maintenance because it automatically accounts for generating the cross-resource reference resolvers in the generated version. This is also one of the reasons we are deprecating `config.Reference.Type`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

A successful uptest run is registered here for a resource affected by this change: https://github.com/crossplane-contrib/provider-upjet-azure/actions/runs/9037709362/

Also checked for any unexpected changes in the generated resolvers (`apis/../zz_generated.resolvers.go` files).

[contribution process]: https://git.io/fj2m9
