### PR TITLE
Fixes #749  : MariaDB Servers documentation - some required fields not documented as such 

### DIFF
--- a/package/crds/dbformariadb.azure.upbound.io_servers.yaml
+++ b/package/crds/dbformariadb.azure.upbound.io_servers.yaml
@@ -331,6 +331,10 @@ spec:
                       to be created.
                     type: string
                 type: object
+                required:
+                  - skuName
+                  - sslEnforcementEnabled
+                  - version
               initProvider:
                 description: |-
                   THIS IS A BETA FIELD. It will be honored


### PR DESCRIPTION
### Description of your changes

Fixes #749 : MariaDB Servers documentation - some required fields not documented as such 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually, since it touches the upbound market documentation only
