### PR TITLE
Fix the problem that `Environment` does not work in OIDC auth

### DIFF
--- a/internal/clients/azure.go
+++ b/internal/clients/azure.go
@@ -205,6 +205,9 @@ func oidcAuth(pc *v1beta1.ProviderConfig, ps *terraform.Setup) error {
 	ps.Configuration[keyTenantID] = *pc.Spec.TenantID
 	ps.Configuration[keyClientID] = *pc.Spec.ClientID
 	ps.Configuration[keyUseOIDC] = "true"
+	if pc.Spec.Environment != nil {
+		ps.Configuration[keyEnvironment] = *pc.Spec.Environment
+	}
 	return nil
 
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes
Fix the issue that the `environment` is always the default value when the source of credentials is `OIDCTokenFile`. We ran into the problem that the tenant cannot be found when it is from China azure even we specify the `Environment` as China.
<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
