### PR TITLE
Prevent the provider from panicking if referenced secrets for NotificationHub are not found

### DIFF
--- a/config/notificationhubs/config.go
+++ b/config/notificationhubs/config.go
@@ -5,13 +5,43 @@
 package notificationhubs
 
 import (
+	"strings"
+
 	"github.com/crossplane/upjet/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // Configure configures notificationhubs group
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_notification_hub", func(r *config.Resource) {
 		r.Kind = "NotificationHub"
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			if diff == nil {
+				return diff, nil
+			}
+			remove := func(prefix string) bool {
+				for k := range diff.Attributes {
+					if strings.HasPrefix(k, prefix+".") && k != prefix+".#" {
+						return false
+					}
+				}
+				return true
+			}
+			// the underlying Terraform resource implementation currently fails
+			// if empty credentials are provided. And in order not to block
+			// MR deletions when the referenced secret is deleted before
+			// the MR, upjet passes empty credentials if the referenced
+			// secret it not found. These are workarounds to prevent the
+			// provider from panicking if the referenced credentials
+			// secret is not found.
+			if remove("gcm_credential") {
+				delete(diff.Attributes, "gcm_credential.#")
+			}
+			if remove("apns_credential") {
+				delete(diff.Attributes, "apns_credential.#")
+			}
+			return diff, nil
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_notification_hub_namespace", func(r *config.Resource) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #730

Upjet does not error when a referenced secret is not found and returns an empty string as the resolved value. This does not play well with the `NotificationHub.notificationhubs` Terraform resource's implementation. Please see [this comment](https://github.com/crossplane-contrib/provider-upjet-azure/issues/730#issuecomment-2133006176) for further details.

This PR works around these issues for the sensitive `gcmCredential` & `apnsCredential` fields by preventing a `nil` value as the sole item in the singleton object list. When upjet resolves an empty string in case a referenced secret is missing, this results in a singleton list whose element is a `nil` value, i.e., `[]any{nil}`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually conducted tests with the `NotificationHub.notificationhubs` objects with references to non-existent & existing secrets in the `spec.forProvider.apnsCredential` and `spec.forProvider.gcmCredential` fields.


[contribution process]: https://git.io/fj2m9
