### PR TITLE
Use crossplane/build submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ UPTEST_LOCAL_VERSION = v0.12.0-9.gac371c9
 UPTEST_LOCAL_CHANNEL = main
 KUSTOMIZE_VERSION = v5.3.0
 YQ_VERSION = v4.40.5
-UXP_VERSION = 1.14.6-up.1
+CROSSPLANE_VERSION = 1.14.6
 
 export UP_VERSION := $(UP_VERSION)
 export UP_CHANNEL := $(UP_CHANNEL)
@@ -367,3 +367,7 @@ delete-build-tags:
 	@EXTRA_BUILDTAGGER_ARGS="--delete" RESTORE_DEEPCOPY_TAGS="true" ./scripts/tag.sh || $(FAIL)
 	@$(OK) Untagging source files.
 endif
+
+# TODO(negz): Update CI to use these targets.
+vendor: modules.download
+vendor.check: modules.check


### PR DESCRIPTION
### Description of your changes

See https://github.com/crossplane/crossplane/issues/1583 for context.

This PR changes `upbound/build` submodule to `crossplane/build` submodule.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Pipelines are green and a successful uptest run: https://github.com/crossplane-contrib/provider-upjet-azure/actions/runs/9302225545


[contribution process]: https://git.io/fj2m9
