### PR TITLE
Fix #760 by making administrator_login & administrator_password optional for connection details

### DIFF
--- a/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
+++ b/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
@@ -31,8 +31,7 @@ spec:
     skuName: GP_Standard_D4s_v3
     storageMb: 32768
     storageTier: P30
-    version: "12"
-    zone: "1"
+    version: "16 "
 
 ---
 

--- a/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
+++ b/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   forProvider:
     administratorLogin: psqladmin
+    autoGeneratePassword: true
     administratorPasswordSecretRef:
       key: example-key
       name: example-secret

--- a/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
+++ b/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
@@ -31,7 +31,7 @@ spec:
     skuName: GP_Standard_D4s_v3
     storageMb: 32768
     storageTier: P30
-    version: "16 "
+    version: "16"
 
 ---
 

--- a/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
+++ b/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
@@ -40,6 +40,7 @@ kind: PrivateDNSZone
 metadata:
   annotations:
     meta.upbound.io/example-id: dbforpostgresql/v1beta2/flexibleserver
+    crossplane.io/external-name: example-upbound.postgres.database.azure.com
   labels:
     testing.upbound.io/example-name: example
   name: example


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes
As described in #760 disabling password auth (only enabling azure ad) results in a panic as no credential details are available. Within this PR checks are introduced which verify the existence of username/password and only then add it to the credential details. 

As general "inspiration" I oriented the change on how it's done for MSSQL: https://github.com/crossplane-contrib/provider-upjet-azure/blob/main/config/sql/config.go#L39

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #760

I have:

- [x] Read and followed Crossplane's [contribution process].
- [] Run `make reviewable` to ensure this PR is ready for review. <- I somehow didn't get that command running. But I doubt it's because of my code changes..
- [] Added `backport release-x.y` labels to auto-backport this PR if necessary. <- Not too sure. I need input from the maintainers if it makes sense to backport?

### How has this code been tested
I run the fixed provider within my cluster with the example MR as described in the bug report. With the applied changes, the panic is not appearing and the .status of the FlexibleServer MR is updated when creating with disabled password auth. 

A successful uptest run of the resource: https://github.com/crossplane-contrib/provider-upjet-azure/actions/runs/9483541667

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
