### PR TITLE
Add userAssignedIdentity reference to AKS cluster

### DIFF
--- a/apis/containerservice/v1beta1/zz_generated.deepcopy.go
+++ b/apis/containerservice/v1beta1/zz_generated.deepcopy.go
@@ -2127,6 +2127,18 @@ func (in *IdentityInitParameters) DeepCopyInto(out *IdentityInitParameters) {
 			}
 		}
 	}
+	if in.IdentityIdsRefs != nil {
+		in, out := &in.IdentityIdsRefs, &out.IdentityIdsRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.IdentityIdsSelector != nil {
+		in, out := &in.IdentityIdsSelector, &out.IdentityIdsSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
 		*out = new(string)
@@ -2198,6 +2210,18 @@ func (in *IdentityParameters) DeepCopyInto(out *IdentityParameters) {
 				**out = **in
 			}
 		}
+	}
+	if in.IdentityIdsRefs != nil {
+		in, out := &in.IdentityIdsRefs, &out.IdentityIdsRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.IdentityIdsSelector != nil {
+		in, out := &in.IdentityIdsSelector, &out.IdentityIdsSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type

--- a/apis/containerservice/v1beta1/zz_generated.resolvers.go
+++ b/apis/containerservice/v1beta1/zz_generated.resolvers.go
@@ -25,6 +25,7 @@ func (mg *KubernetesCluster) ResolveReferences( // ResolveReferences of this Kub
 	r := reference.NewAPIResolver(c, mg)
 
 	var rsp reference.ResolutionResponse
+	var mrsp reference.MultiResolutionResponse
 	var err error
 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.APIServerAccessProfile); i3++ {
@@ -109,6 +110,27 @@ func (mg *KubernetesCluster) ResolveReferences( // ResolveReferences of this Kub
 		}
 		mg.Spec.ForProvider.DefaultNodePool[i3].VnetSubnetID = reference.ToPtrValue(rsp.ResolvedValue)
 		mg.Spec.ForProvider.DefaultNodePool[i3].VnetSubnetIDRef = rsp.ResolvedReference
+
+	}
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.Identity); i3++ {
+		{
+			m, l, err = apisresolver.GetManagedResource("managedidentity.azure.upbound.io", "v1beta1", "UserAssignedIdentity", "UserAssignedIdentityList")
+			if err != nil {
+				return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+			}
+			mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+				CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Identity[i3].IdentityIds),
+				Extract:       rconfig.ExtractResourceID(),
+				References:    mg.Spec.ForProvider.Identity[i3].IdentityIdsRefs,
+				Selector:      mg.Spec.ForProvider.Identity[i3].IdentityIdsSelector,
+				To:            reference.To{List: l, Managed: m},
+			})
+		}
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.ForProvider.Identity[i3].IdentityIds")
+		}
+		mg.Spec.ForProvider.Identity[i3].IdentityIds = reference.ToPtrValues(mrsp.ResolvedValues)
+		mg.Spec.ForProvider.Identity[i3].IdentityIdsRefs = mrsp.ResolvedReferences
 
 	}
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.IngressApplicationGateway); i3++ {
@@ -252,6 +274,27 @@ func (mg *KubernetesCluster) ResolveReferences( // ResolveReferences of this Kub
 		}
 		mg.Spec.InitProvider.DefaultNodePool[i3].VnetSubnetID = reference.ToPtrValue(rsp.ResolvedValue)
 		mg.Spec.InitProvider.DefaultNodePool[i3].VnetSubnetIDRef = rsp.ResolvedReference
+
+	}
+	for i3 := 0; i3 < len(mg.Spec.InitProvider.Identity); i3++ {
+		{
+			m, l, err = apisresolver.GetManagedResource("managedidentity.azure.upbound.io", "v1beta1", "UserAssignedIdentity", "UserAssignedIdentityList")
+			if err != nil {
+				return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+			}
+			mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+				CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Identity[i3].IdentityIds),
+				Extract:       rconfig.ExtractResourceID(),
+				References:    mg.Spec.InitProvider.Identity[i3].IdentityIdsRefs,
+				Selector:      mg.Spec.InitProvider.Identity[i3].IdentityIdsSelector,
+				To:            reference.To{List: l, Managed: m},
+			})
+		}
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.InitProvider.Identity[i3].IdentityIds")
+		}
+		mg.Spec.InitProvider.Identity[i3].IdentityIds = reference.ToPtrValues(mrsp.ResolvedValues)
+		mg.Spec.InitProvider.Identity[i3].IdentityIdsRefs = mrsp.ResolvedReferences
 
 	}
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.IngressApplicationGateway); i3++ {

--- a/apis/containerservice/v1beta1/zz_kubernetescluster_types.go
+++ b/apis/containerservice/v1beta1/zz_kubernetescluster_types.go
@@ -1003,8 +1003,18 @@ type HTTPProxyConfigParameters struct {
 type IdentityInitParameters struct {
 
 	// Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/managedidentity/v1beta1.UserAssignedIdentity
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +listType=set
 	IdentityIds []*string `json:"identityIds,omitempty" tf:"identity_ids,omitempty"`
+
+	// References to UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsRefs []v1.Reference `json:"identityIdsRefs,omitempty" tf:"-"`
+
+	// Selector for a list of UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsSelector *v1.Selector `json:"identityIdsSelector,omitempty" tf:"-"`
 
 	// Specifies the type of Managed Service Identity that should be configured on this Kubernetes Cluster. Possible values are SystemAssigned or UserAssigned.
 	Type *string `json:"type,omitempty" tf:"type,omitempty"`
@@ -1029,9 +1039,19 @@ type IdentityObservation struct {
 type IdentityParameters struct {
 
 	// Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/managedidentity/v1beta1.UserAssignedIdentity
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	IdentityIds []*string `json:"identityIds,omitempty" tf:"identity_ids,omitempty"`
+
+	// References to UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsRefs []v1.Reference `json:"identityIdsRefs,omitempty" tf:"-"`
+
+	// Selector for a list of UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsSelector *v1.Selector `json:"identityIdsSelector,omitempty" tf:"-"`
 
 	// Specifies the type of Managed Service Identity that should be configured on this Kubernetes Cluster. Possible values are SystemAssigned or UserAssigned.
 	// +kubebuilder:validation:Optional

--- a/apis/containerservice/v1beta2/zz_generated.deepcopy.go
+++ b/apis/containerservice/v1beta2/zz_generated.deepcopy.go
@@ -2043,6 +2043,18 @@ func (in *IdentityInitParameters) DeepCopyInto(out *IdentityInitParameters) {
 			}
 		}
 	}
+	if in.IdentityIdsRefs != nil {
+		in, out := &in.IdentityIdsRefs, &out.IdentityIdsRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.IdentityIdsSelector != nil {
+		in, out := &in.IdentityIdsSelector, &out.IdentityIdsSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
 		*out = new(string)
@@ -2114,6 +2126,18 @@ func (in *IdentityParameters) DeepCopyInto(out *IdentityParameters) {
 				**out = **in
 			}
 		}
+	}
+	if in.IdentityIdsRefs != nil {
+		in, out := &in.IdentityIdsRefs, &out.IdentityIdsRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.IdentityIdsSelector != nil {
+		in, out := &in.IdentityIdsSelector, &out.IdentityIdsSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type

--- a/apis/containerservice/v1beta2/zz_generated.resolvers.go
+++ b/apis/containerservice/v1beta2/zz_generated.resolvers.go
@@ -25,6 +25,7 @@ func (mg *KubernetesCluster) ResolveReferences( // ResolveReferences of this Kub
 	r := reference.NewAPIResolver(c, mg)
 
 	var rsp reference.ResolutionResponse
+	var mrsp reference.MultiResolutionResponse
 	var err error
 
 	if mg.Spec.ForProvider.APIServerAccessProfile != nil {
@@ -109,6 +110,27 @@ func (mg *KubernetesCluster) ResolveReferences( // ResolveReferences of this Kub
 		}
 		mg.Spec.ForProvider.DefaultNodePool.VnetSubnetID = reference.ToPtrValue(rsp.ResolvedValue)
 		mg.Spec.ForProvider.DefaultNodePool.VnetSubnetIDRef = rsp.ResolvedReference
+
+	}
+	if mg.Spec.ForProvider.Identity != nil {
+		{
+			m, l, err = apisresolver.GetManagedResource("managedidentity.azure.upbound.io", "v1beta1", "UserAssignedIdentity", "UserAssignedIdentityList")
+			if err != nil {
+				return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+			}
+			mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+				CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Identity.IdentityIds),
+				Extract:       rconfig.ExtractResourceID(),
+				References:    mg.Spec.ForProvider.Identity.IdentityIdsRefs,
+				Selector:      mg.Spec.ForProvider.Identity.IdentityIdsSelector,
+				To:            reference.To{List: l, Managed: m},
+			})
+		}
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.ForProvider.Identity.IdentityIds")
+		}
+		mg.Spec.ForProvider.Identity.IdentityIds = reference.ToPtrValues(mrsp.ResolvedValues)
+		mg.Spec.ForProvider.Identity.IdentityIdsRefs = mrsp.ResolvedReferences
 
 	}
 	if mg.Spec.ForProvider.IngressApplicationGateway != nil {
@@ -252,6 +274,27 @@ func (mg *KubernetesCluster) ResolveReferences( // ResolveReferences of this Kub
 		}
 		mg.Spec.InitProvider.DefaultNodePool.VnetSubnetID = reference.ToPtrValue(rsp.ResolvedValue)
 		mg.Spec.InitProvider.DefaultNodePool.VnetSubnetIDRef = rsp.ResolvedReference
+
+	}
+	if mg.Spec.InitProvider.Identity != nil {
+		{
+			m, l, err = apisresolver.GetManagedResource("managedidentity.azure.upbound.io", "v1beta1", "UserAssignedIdentity", "UserAssignedIdentityList")
+			if err != nil {
+				return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+			}
+			mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+				CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.Identity.IdentityIds),
+				Extract:       rconfig.ExtractResourceID(),
+				References:    mg.Spec.InitProvider.Identity.IdentityIdsRefs,
+				Selector:      mg.Spec.InitProvider.Identity.IdentityIdsSelector,
+				To:            reference.To{List: l, Managed: m},
+			})
+		}
+		if err != nil {
+			return errors.Wrap(err, "mg.Spec.InitProvider.Identity.IdentityIds")
+		}
+		mg.Spec.InitProvider.Identity.IdentityIds = reference.ToPtrValues(mrsp.ResolvedValues)
+		mg.Spec.InitProvider.Identity.IdentityIdsRefs = mrsp.ResolvedReferences
 
 	}
 	if mg.Spec.InitProvider.IngressApplicationGateway != nil {

--- a/apis/containerservice/v1beta2/zz_kubernetescluster_types.go
+++ b/apis/containerservice/v1beta2/zz_kubernetescluster_types.go
@@ -1002,8 +1002,18 @@ type HTTPProxyConfigParameters struct {
 type IdentityInitParameters struct {
 
 	// Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/managedidentity/v1beta1.UserAssignedIdentity
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +listType=set
 	IdentityIds []*string `json:"identityIds,omitempty" tf:"identity_ids,omitempty"`
+
+	// References to UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsRefs []v1.Reference `json:"identityIdsRefs,omitempty" tf:"-"`
+
+	// Selector for a list of UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsSelector *v1.Selector `json:"identityIdsSelector,omitempty" tf:"-"`
 
 	// Specifies the type of Managed Service Identity that should be configured on this Kubernetes Cluster. Possible values are SystemAssigned or UserAssigned.
 	Type *string `json:"type,omitempty" tf:"type,omitempty"`
@@ -1028,9 +1038,19 @@ type IdentityObservation struct {
 type IdentityParameters struct {
 
 	// Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/managedidentity/v1beta1.UserAssignedIdentity
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	IdentityIds []*string `json:"identityIds,omitempty" tf:"identity_ids,omitempty"`
+
+	// References to UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsRefs []v1.Reference `json:"identityIdsRefs,omitempty" tf:"-"`
+
+	// Selector for a list of UserAssignedIdentity in managedidentity to populate identityIds.
+	// +kubebuilder:validation:Optional
+	IdentityIdsSelector *v1.Selector `json:"identityIdsSelector,omitempty" tf:"-"`
 
 	// Specifies the type of Managed Service Identity that should be configured on this Kubernetes Cluster. Possible values are SystemAssigned or UserAssigned.
 	// +kubebuilder:validation:Optional

--- a/config/containerservice/config.go
+++ b/config/containerservice/config.go
@@ -80,7 +80,6 @@ func Configure(p *config.Provider) {
 			return nil, nil
 		}
 		r.MetaResource.ArgumentDocs["api_server_authorized_ip_ranges"] = "Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`"
-
 		r.References["identity.identity_ids"] = config.Reference{
 			TerraformName: "azurerm_user_assigned_identity",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,

--- a/config/containerservice/config.go
+++ b/config/containerservice/config.go
@@ -80,6 +80,11 @@ func Configure(p *config.Provider) {
 			return nil, nil
 		}
 		r.MetaResource.ArgumentDocs["api_server_authorized_ip_ranges"] = "Deprecated in favor of `spec.forProvider.apiServerAccessProfile[0].authorizedIpRanges`"
+
+		r.References["identity.identity_ids"] = config.Reference{
+			TerraformName: "azurerm_user_assigned_identity",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_kubernetes_cluster_node_pool", func(r *config.Resource) {

--- a/examples/containerservice/v1beta2/kubernetescluster-with-identity.yaml
+++ b/examples/containerservice/v1beta2/kubernetescluster-with-identity.yaml
@@ -9,7 +9,7 @@ metadata:
     meta.upbound.io/example-id: containerservice/v1beta2/kubernetescluster
   labels:
     testing.upbound.io/example-name: example
-  name: example
+  name: example-kc-with-uai
 spec:
   forProvider:
     apiServerAccessProfile:
@@ -19,13 +19,15 @@ spec:
       name: default
       nodeCount: 1
       vmSize: Standard_D2_v2
+      upgradeSettings:
+        maxSurge: '10%'
     dnsPrefix: exampleaks1
     identity:
       type: UserAssigned
       identityIdsSelector:
         matchLabels:
           testing.upbound.io/example-name: exmple-managedidentity
-    location: West Europe
+    location: North Europe
     resourceGroupNameSelector:
       matchLabels:
         testing.upbound.io/example-name: example-containerservice
@@ -39,10 +41,10 @@ kind: ResourceGroup
 metadata:
   labels:
     testing.upbound.io/example-name: example-containerservice
-  name: example-containerservice-${Rand.RFC1123Subdomain}
+  name: example-rg-kc-with-uai
 spec:
   forProvider:
-    location: West Europe
+    location: North Europe
 
 ---
 
@@ -51,10 +53,10 @@ kind: UserAssignedIdentity
 metadata:
   labels:
     testing.upbound.io/example-name: exmple-managedidentity
-  name: example-managedidentity
+  name: example-uai-kc
 spec:
   forProvider:
-    location: West Europe
+    location: North Europe
     name: exmple-managedidentity
     resourceGroupNameSelector:
       matchLabels:

--- a/examples/containerservice/v1beta2/kubernetescluster-with-identity.yaml
+++ b/examples/containerservice/v1beta2/kubernetescluster-with-identity.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: containerservice.azure.upbound.io/v1beta2
+kind: KubernetesCluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: containerservice/v1beta2/kubernetescluster
+  labels:
+    testing.upbound.io/example-name: example
+  name: example
+spec:
+  forProvider:
+    apiServerAccessProfile:
+      authorizedIpRanges:
+      - 192.168.1.0/24
+    defaultNodePool:
+      name: default
+      nodeCount: 1
+      vmSize: Standard_D2_v2
+    dnsPrefix: exampleaks1
+    identity:
+      type: UserAssigned
+      identityIdsSelector:
+        matchLabels:
+          testing.upbound.io/example-name: exmple-managedidentity
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-containerservice
+    tags:
+      Environment: Production
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  labels:
+    testing.upbound.io/example-name: example-containerservice
+  name: example-containerservice-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    location: West Europe
+
+---
+
+apiVersion: managedidentity.azure.upbound.io/v1beta1
+kind: UserAssignedIdentity
+metadata:
+  labels:
+    testing.upbound.io/example-name: exmple-managedidentity
+  name: example-managedidentity
+spec:
+  forProvider:
+    location: West Europe
+    name: exmple-managedidentity
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-containerservice

--- a/package/crds/containerservice.azure.upbound.io_kubernetesclusters.yaml
+++ b/package/crds/containerservice.azure.upbound.io_kubernetesclusters.yaml
@@ -6912,6 +6912,85 @@ spec:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
+                      identityIdsRefs:
+                        description: References to UserAssignedIdentity in managedidentity
+                          to populate identityIds.
+                        items:
+                          description: A Reference to a named object.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      identityIdsSelector:
+                        description: Selector for a list of UserAssignedIdentity in
+                          managedidentity to populate identityIds.
+                        properties:
+                          matchControllerRef:
+                            description: |-
+                              MatchControllerRef ensures an object with the same controller reference
+                              as the selecting object is selected.
+                            type: boolean
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: MatchLabels ensures an object with matching
+                              labels is selected.
+                            type: object
+                          policy:
+                            description: Policies for selection.
+                            properties:
+                              resolution:
+                                default: Required
+                                description: |-
+                                  Resolution specifies whether resolution of this reference is required.
+                                  The default is 'Required', which means the reconcile will fail if the
+                                  reference cannot be resolved. 'Optional' means this reference will be
+                                  a no-op if it cannot be resolved.
+                                enum:
+                                - Required
+                                - Optional
+                                type: string
+                              resolve:
+                                description: |-
+                                  Resolve specifies when this reference should be resolved. The default
+                                  is 'IfNotPresent', which will attempt to resolve the reference only when
+                                  the corresponding field is not present. Use 'Always' to resolve the
+                                  reference on every reconcile.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                type: string
+                            type: object
+                        type: object
                       type:
                         description: Specifies the type of Managed Service Identity
                           that should be configured on this Kubernetes Cluster. Possible
@@ -8853,6 +8932,85 @@ spec:
                           type: string
                         type: array
                         x-kubernetes-list-type: set
+                      identityIdsRefs:
+                        description: References to UserAssignedIdentity in managedidentity
+                          to populate identityIds.
+                        items:
+                          description: A Reference to a named object.
+                          properties:
+                            name:
+                              description: Name of the referenced object.
+                              type: string
+                            policy:
+                              description: Policies for referencing.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      identityIdsSelector:
+                        description: Selector for a list of UserAssignedIdentity in
+                          managedidentity to populate identityIds.
+                        properties:
+                          matchControllerRef:
+                            description: |-
+                              MatchControllerRef ensures an object with the same controller reference
+                              as the selecting object is selected.
+                            type: boolean
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: MatchLabels ensures an object with matching
+                              labels is selected.
+                            type: object
+                          policy:
+                            description: Policies for selection.
+                            properties:
+                              resolution:
+                                default: Required
+                                description: |-
+                                  Resolution specifies whether resolution of this reference is required.
+                                  The default is 'Required', which means the reconcile will fail if the
+                                  reference cannot be resolved. 'Optional' means this reference will be
+                                  a no-op if it cannot be resolved.
+                                enum:
+                                - Required
+                                - Optional
+                                type: string
+                              resolve:
+                                description: |-
+                                  Resolve specifies when this reference should be resolved. The default
+                                  is 'IfNotPresent', which will attempt to resolve the reference only when
+                                  the corresponding field is not present. Use 'Always' to resolve the
+                                  reference on every reconcile.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                type: string
+                            type: object
+                        type: object
                       type:
                         description: Specifies the type of Managed Service Identity
                           that should be configured on this Kubernetes Cluster. Possible

--- a/package/crds/containerservice.azure.upbound.io_kubernetesclusters.yaml
+++ b/package/crds/containerservice.azure.upbound.io_kubernetesclusters.yaml
@@ -1117,6 +1117,85 @@ spec:
                             type: string
                           type: array
                           x-kubernetes-list-type: set
+                        identityIdsRefs:
+                          description: References to UserAssignedIdentity in managedidentity
+                            to populate identityIds.
+                          items:
+                            description: A Reference to a named object.
+                            properties:
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              policy:
+                                description: Policies for referencing.
+                                properties:
+                                  resolution:
+                                    default: Required
+                                    description: |-
+                                      Resolution specifies whether resolution of this reference is required.
+                                      The default is 'Required', which means the reconcile will fail if the
+                                      reference cannot be resolved. 'Optional' means this reference will be
+                                      a no-op if it cannot be resolved.
+                                    enum:
+                                    - Required
+                                    - Optional
+                                    type: string
+                                  resolve:
+                                    description: |-
+                                      Resolve specifies when this reference should be resolved. The default
+                                      is 'IfNotPresent', which will attempt to resolve the reference only when
+                                      the corresponding field is not present. Use 'Always' to resolve the
+                                      reference on every reconcile.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        identityIdsSelector:
+                          description: Selector for a list of UserAssignedIdentity
+                            in managedidentity to populate identityIds.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         type:
                           description: Specifies the type of Managed Service Identity
                             that should be configured on this Kubernetes Cluster.
@@ -3151,6 +3230,85 @@ spec:
                             type: string
                           type: array
                           x-kubernetes-list-type: set
+                        identityIdsRefs:
+                          description: References to UserAssignedIdentity in managedidentity
+                            to populate identityIds.
+                          items:
+                            description: A Reference to a named object.
+                            properties:
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              policy:
+                                description: Policies for referencing.
+                                properties:
+                                  resolution:
+                                    default: Required
+                                    description: |-
+                                      Resolution specifies whether resolution of this reference is required.
+                                      The default is 'Required', which means the reconcile will fail if the
+                                      reference cannot be resolved. 'Optional' means this reference will be
+                                      a no-op if it cannot be resolved.
+                                    enum:
+                                    - Required
+                                    - Optional
+                                    type: string
+                                  resolve:
+                                    description: |-
+                                      Resolve specifies when this reference should be resolved. The default
+                                      is 'IfNotPresent', which will attempt to resolve the reference only when
+                                      the corresponding field is not present. Use 'Always' to resolve the
+                                      reference on every reconcile.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        identityIdsSelector:
+                          description: Selector for a list of UserAssignedIdentity
+                            in managedidentity to populate identityIds.
+                          properties:
+                            matchControllerRef:
+                              description: |-
+                                MatchControllerRef ensures an object with the same controller reference
+                                as the selecting object is selected.
+                              type: boolean
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: MatchLabels ensures an object with matching
+                                labels is selected.
+                              type: object
+                            policy:
+                              description: Policies for selection.
+                              properties:
+                                resolution:
+                                  default: Required
+                                  description: |-
+                                    Resolution specifies whether resolution of this reference is required.
+                                    The default is 'Required', which means the reconcile will fail if the
+                                    reference cannot be resolved. 'Optional' means this reference will be
+                                    a no-op if it cannot be resolved.
+                                  enum:
+                                  - Required
+                                  - Optional
+                                  type: string
+                                resolve:
+                                  description: |-
+                                    Resolve specifies when this reference should be resolved. The default
+                                    is 'IfNotPresent', which will attempt to resolve the reference only when
+                                    the corresponding field is not present. Use 'Always' to resolve the
+                                    reference on every reconcile.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  type: string
+                              type: object
+                          type: object
                         type:
                           description: Specifies the type of Managed Service Identity
                             that should be configured on this Kubernetes Cluster.


### PR DESCRIPTION
### Description of your changes

This adds a missing cross reference to UserAssignedIdentities within AKS. 
Fixes #662

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I couldn't test it, because I could not make `make uptest` work (installing: No such file or directory). 
Hope that the CI pipeline can give me feedback.

[contribution process]: https://git.io/fj2m9
