### PR TITLE
Filter empty length key diffs in Storage Account resource

### DIFF
--- a/config/storage/config.go
+++ b/config/storage/config.go
@@ -5,14 +5,51 @@
 package storage
 
 import (
+	"errors"
+
 	"github.com/crossplane/upjet/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/upbound/provider-azure/apis/rconfig"
 	"github.com/upbound/provider-azure/config/common"
 )
 
 // Configure configures storage group
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
+	p.AddResourceConfigurator("azurerm_storage_account", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			// skip diff customization on create
+			if state == nil || state.Empty() {
+				return diff, nil
+			}
+			if config == nil {
+				return nil, errors.New("resource config cannot be nil")
+			}
+			// skip no diff or destroy diffs
+			if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+				return diff, nil
+			}
+
+			lengthDiffKeys := []string{
+				"blob_properties.#",
+				"share_properties.#",
+				"queue_properties.#",
+			}
+			for _, key := range lengthDiffKeys {
+				// Note(cem): We should consider filtering effectively-empty
+				// (Old = "" and New = "") length keys (`*.#` and `*.%`) in
+				// Upjet. Doing so _should be_ safe, but in case we are afraid
+				// to deploy at scale, we might tie the functionality to a
+				// resource configuration flag, as a precaution.
+				if diff.Attributes[key] != nil && diff.Attributes[key].Old == "" && diff.Attributes[key].New == "" {
+					delete(diff.Attributes, key)
+				}
+			}
+
+			return diff, nil
+		}
+	})
+
 	p.AddResourceConfigurator("azurerm_storage_blob", func(r *config.Resource) {
 		r.References["storage_account_name"] = config.Reference{
 			TerraformName: "azurerm_storage_account",

--- a/examples/storage/v1beta1/account.yaml
+++ b/examples/storage/v1beta1/account.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Note that this resource is not _properly_ Uptestable, because Uptest
+# cannot generate a random string that conforms to Azure Storage
+# Account naming criteria:
+# https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#storage-account-name
+#
+# Uptest should succeed, as long as the hardcoded `metadata.name`
+# below is available.
+
+apiVersion: storage.azure.upbound.io/v1beta1
+kind: Account
+metadata:
+  annotations:
+    meta.upbound.io/example-id: storage/v1beta1/account
+  labels:
+    testing.upbound.io/example-name: example-storage
+  name: examplesa539891
+spec:
+  forProvider:
+    accountReplicationType: LRS
+    accountTier: Standard
+    location: "West Europe"
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-storage
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: storage/v1beta1/account
+  labels:
+    testing.upbound.io/example-name: example-storage
+  name: example-storage-${Rand.RFC1123Subdomain}
+spec:
+  forProvider:
+    location: "West Europe"
+    tags:
+      provisioner: crossplane


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #683, #807 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

See minimally-working example manifest's [Uptest result](https://github.com/crossplane-contrib/provider-upjet-azure/actions/runs/10993425918).

Example manifest, which is introduced by this PR, won't reproduce the linked issues above. Therefore, apply the following manifest to reproduce the error:

```yaml
apiVersion: storage.azure.upbound.io/v1beta1
kind: Account
metadata:
  name: issue816account
spec:
  deletionPolicy: Delete
  forProvider:
    accountKind: BlockBlobStorage
    accountReplicationType: ZRS
    accountTier: Premium
    allowNestedItemsToBePublic: false
    crossTenantReplicationEnabled: true
    enableHttpsTrafficOnly: true
    infrastructureEncryptionEnabled: true
    isHnsEnabled: true
    localUserEnabled: true
    location: East US
    minTlsVersion: TLS1_2
    networkRules:
      - defaultAction: Deny
        ipRules:
        - "0.0.0.0/0"
    nfsv3Enabled: true
    publicNetworkAccessEnabled: true
    queueEncryptionKeyType: Service
    resourceGroupName: example-resources-test
    sharedAccessKeyEnabled: true
    tableEncryptionKeyType: Service

---

apiVersion: azure.upbound.io/v1beta1
kind: ResourceGroup
metadata:
  name: example-resources-test
spec:
  forProvider:
    location: "West Europe"
    tags:
      provisioner: crossplane
```

[contribution process]: https://git.io/fj2m9
