### PR TITLE
Add uptestable example for PrivateDNSZoneVirtualNetworkLink

### DIFF
--- a/examples/network/v1beta1/privatednszonevirtualnetworklink.yaml
+++ b/examples/network/v1beta1/privatednszonevirtualnetworklink.yaml
@@ -5,12 +5,68 @@
 apiVersion: network.azure.upbound.io/v1beta1
 kind: PrivateDNSZoneVirtualNetworkLink
 metadata:
-  name: example
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/privatednszonevirtualnetworklink
+  labels:
+    testing.upbound.io/example-name: example
+  name: example-test-pdzvnl
 spec:
   forProvider:
-    privateDnsZoneNameRef:
-      name: example
-    resourceGroupNameRef:
-      name: example
-    virtualNetworkIdRef:
-      name: example
+    registrationEnabled: true
+    privateDnsZoneName: example.com
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    virtualNetworkIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta2
+kind: PrivateDNSZone
+metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/privatednszonevirtualnetworklink
+    crossplane.io/external-name: example.com
+  labels:
+    testing.upbound.io/example-name: example
+  name: example-test-pdzvnl
+spec:
+  forProvider:
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+
+---
+
+apiVersion: azure.upbound.io/v1beta1
+kind: ResourceGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/privatednszonevirtualnetworklink
+  labels:
+    testing.upbound.io/example-name: example
+  name: example-test-pdzvnl
+spec:
+  forProvider:
+    location: West Europe
+
+---
+
+apiVersion: network.azure.upbound.io/v1beta2
+kind: VirtualNetwork
+metadata:
+  annotations:
+    meta.upbound.io/example-id: network/v1beta1/privatednszonevirtualnetworklink
+  labels:
+    testing.upbound.io/example-name: example
+  name: example-test-pdzvnl
+spec:
+  forProvider:
+    addressSpace:
+    - 10.0.0.0/16
+    location: West Europe
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example


### PR DESCRIPTION
### Description of your changes

Adds uptestable example for the `PrivateDNSZoneVirtualNetworkLink` resource.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Uptest

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
