### PR TITLE
Ignore lateinitialize for secret field in the ContainerApp resource

### DIFF
--- a/apis/containerapp/v1beta1/zz_containerapp_terraformed.go
+++ b/apis/containerapp/v1beta1/zz_containerapp_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ContainerApp) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Secret"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/containerapp/v1beta2/zz_containerapp_terraformed.go
+++ b/apis/containerapp/v1beta2/zz_containerapp_terraformed.go
@@ -118,6 +118,7 @@ func (tr *ContainerApp) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Secret"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/containerapp/config.go
+++ b/config/containerapp/config.go
@@ -17,6 +17,9 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = group
 		r.TerraformResource.Schema["secret"].Elem.(*schema.Resource).
 			Schema["name"].Sensitive = true
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"secret"},
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_container_app_environment", func(r *config.Resource) {


### PR DESCRIPTION
### Description of your changes

This PR ignores lateinitialize of the secret field in the ContainerApp resource.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually and uptest

[contribution process]: https://git.io/fj2m9
