### PR TITLE
Update go version to 1.23.5 [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/upbound/provider-azure
 
-go 1.23
+go 1.23.5
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

The `go1.23`means automatically consuming the latest patch version. However, in the pipelines we need specific patch version. So, we updated it here.

| Name | Change | Type | Vulnerability | Severity |
|---|---|---|---|---|
| stdlib | `go1.23` -> `go1.23.5` | go-module | CVE-2024-45341 | Medium |
| stdlib | `go1.23` -> `go1.23.5` | go-module | CVE-2024-45336 | Medium |

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

https://github.com/crossplane-contrib/provider-upjet-azure/actions/runs/13133543451

[contribution process]: https://git.io/fj2m9
