### PR TITLE
Bump Terraform provider version to v3.117.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PROJECT_NAME := provider-$(PROVIDER_NAME)
 PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
 
 export TERRAFORM_VERSION ?= 1.5.5
-export TERRAFORM_PROVIDER_VERSION ?= 3.117.0
+export TERRAFORM_PROVIDER_VERSION ?= 3.117.1
 export TERRAFORM_PROVIDER_SOURCE ?= hashicorp/azurerm
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/hashicorp/terraform-provider-azurerm
 export TERRAFORM_DOCS_PATH ?= website/docs/r

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-azure-helpers v0.70.1 // indirect
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240731.1212841 // indirect
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240819.1075239 // indirect
 	github.com/hashicorp/go-azure-sdk/sdk v0.20241025.1143247 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -166,4 +166,4 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.4.0 // indirect
 )
 
-replace github.com/hashicorp/terraform-provider-azurerm => github.com/upbound/terraform-provider-azurerm v0.0.0-20241203092116-b74bc0a2e2d8
+replace github.com/hashicorp/terraform-provider-azurerm => github.com/upbound/terraform-provider-azurerm v0.0.0-20250417173331-4074132d9d03

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.70.1 h1:7hlnRrZobMZxpOzdlNEsayzAayj/KRG4wpDS1jgo4GM=
 github.com/hashicorp/go-azure-helpers v0.70.1/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240731.1212841 h1:H7BkxZl0qitdWq7sEGzNqkn5/11YTamwq2XTI8/7Jq0=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240731.1212841/go.mod h1:/4Ly9Gppp/Nu9AaWDfod6atYQ4n2OqN0ERpE2xZQz8A=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240819.1075239 h1:Vs3yqWI0DEy0AswanjEB+Vj7486rc1O6QCPv8uX2qgg=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20240819.1075239/go.mod h1:lDFtVt7Q/VcFqyu/SlE9IhtroHlsAurHpw0YMhsa5Oc=
 github.com/hashicorp/go-azure-sdk/sdk v0.20241025.1143247 h1:NoYFgxtEsxHhE6TyJ6DRXqHLcxZ0cmrpGxNPio0lT84=
 github.com/hashicorp/go-azure-sdk/sdk v0.20241025.1143247/go.mod h1:dMKF6bXrgGmy1d3pLzkmBpG2JIHgSAV2/OMSCEgyMwE=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
@@ -330,8 +330,8 @@ github.com/tombuildsstuff/giovanni v0.27.0 h1:3CDNjauK78FIhvvCp0SAHlvNcPTcofR6zQ
 github.com/tombuildsstuff/giovanni v0.27.0/go.mod h1:SviBdlwdVn2HyArdRABBqMUODBJ2adQHi+RFEVaO05I=
 github.com/tombuildsstuff/kermit v0.20240122.1123108 h1:icQaxsv/ANv/KC4Sr0V1trrWA/XIL+3QAVBDpiSTgj8=
 github.com/tombuildsstuff/kermit v0.20240122.1123108/go.mod h1:T3YBVFhRV4qA7SbnRaNE6eapIMpKDA9rG/V7Ocsjlno=
-github.com/upbound/terraform-provider-azurerm v0.0.0-20241203092116-b74bc0a2e2d8 h1:3b85peJKHf/QIEllUgK64z/oG8fuDhnmE7G5pl5i1mg=
-github.com/upbound/terraform-provider-azurerm v0.0.0-20241203092116-b74bc0a2e2d8/go.mod h1:6p9OsjLZCi9+P2vq6wkk7cJC0AtYHMyQ3zvLSN7tjWI=
+github.com/upbound/terraform-provider-azurerm v0.0.0-20250417173331-4074132d9d03 h1:Nszp7xxiBx2mSFaBto+QU8lxaFG/SUwmIuy67sAFFcw=
+github.com/upbound/terraform-provider-azurerm v0.0.0-20250417173331-4074132d9d03/go.mod h1:pg7U97XV25ZfituyjCR0NrtqlJ3PpXUX/lJUxNUUKK4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Signed-off-by: drew0ps <ad.marton@proton.me>

<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

This PR bumps Terraform provider version to v3.117.1

Fixes [949](https://github.com/crossplane-contrib/provider-upjet-azure/issues/949)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Multiple uptests
- Ran make e2e targed against trustedaccessrolebinding example - successfully created and managed:

```
k get trustedaccessrolebindings.authorization.azure.upbound.io 
NAME                    SYNCED   READY   EXTERNAL-NAME           AGE
example-ta-rb   True     True    example-ta-rb   25m
```

[contribution process]: https://git.io/fj2m9
