### PR TITLE
Configure map-merge for application gateway

### DIFF
--- a/apis/network/v1beta2/zz_applicationgateway_types.go
+++ b/apis/network/v1beta2/zz_applicationgateway_types.go
@@ -43,12 +43,16 @@ type ApplicationGatewayInitParameters struct {
 	ForceFirewallPolicyAssociation *bool `json:"forceFirewallPolicyAssociation,omitempty" tf:"force_firewall_policy_association,omitempty"`
 
 	// One or more frontend_ip_configuration blocks as defined below.
+	// +listType=map
+	// +listMapKey=name
 	FrontendIPConfiguration []FrontendIPConfigurationInitParameters `json:"frontendIpConfiguration,omitempty" tf:"frontend_ip_configuration,omitempty"`
 
 	// One or more frontend_port blocks as defined below.
 	FrontendPort []FrontendPortInitParameters `json:"frontendPort,omitempty" tf:"frontend_port,omitempty"`
 
 	// One or more gateway_ip_configuration blocks as defined below.
+	// +listType=map
+	// +listMapKey=name
 	GatewayIPConfiguration []GatewayIPConfigurationInitParameters `json:"gatewayIpConfiguration,omitempty" tf:"gateway_ip_configuration,omitempty"`
 
 	// A global block as defined below.
@@ -141,12 +145,16 @@ type ApplicationGatewayObservation struct {
 	ForceFirewallPolicyAssociation *bool `json:"forceFirewallPolicyAssociation,omitempty" tf:"force_firewall_policy_association,omitempty"`
 
 	// One or more frontend_ip_configuration blocks as defined below.
+	// +listType=map
+	// +listMapKey=name
 	FrontendIPConfiguration []FrontendIPConfigurationObservation `json:"frontendIpConfiguration,omitempty" tf:"frontend_ip_configuration,omitempty"`
 
 	// One or more frontend_port blocks as defined below.
 	FrontendPort []FrontendPortObservation `json:"frontendPort,omitempty" tf:"frontend_port,omitempty"`
 
 	// One or more gateway_ip_configuration blocks as defined below.
+	// +listType=map
+	// +listMapKey=name
 	GatewayIPConfiguration []GatewayIPConfigurationObservation `json:"gatewayIpConfiguration,omitempty" tf:"gateway_ip_configuration,omitempty"`
 
 	// A global block as defined below.
@@ -258,6 +266,8 @@ type ApplicationGatewayParameters struct {
 
 	// One or more frontend_ip_configuration blocks as defined below.
 	// +kubebuilder:validation:Optional
+	// +listType=map
+	// +listMapKey=name
 	FrontendIPConfiguration []FrontendIPConfigurationParameters `json:"frontendIpConfiguration,omitempty" tf:"frontend_ip_configuration,omitempty"`
 
 	// One or more frontend_port blocks as defined below.
@@ -266,6 +276,8 @@ type ApplicationGatewayParameters struct {
 
 	// One or more gateway_ip_configuration blocks as defined below.
 	// +kubebuilder:validation:Optional
+	// +listType=map
+	// +listMapKey=name
 	GatewayIPConfiguration []GatewayIPConfigurationParameters `json:"gatewayIpConfiguration,omitempty" tf:"gateway_ip_configuration,omitempty"`
 
 	// A global block as defined below.

--- a/config/network/config.go
+++ b/config/network/config.go
@@ -478,6 +478,26 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_public_ip",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.ServerSideApplyMergeStrategies["frontend_ip_configuration"] = config.MergeStrategy{
+			ListMergeStrategy: config.ListMergeStrategy{
+				ListMapKeys: config.ListMapKeys{
+					Keys: []string{
+						"name",
+					},
+				},
+				MergeStrategy: config.ListTypeMap,
+			},
+		}
+		r.ServerSideApplyMergeStrategies["gateway_ip_configuration"] = config.MergeStrategy{
+			ListMergeStrategy: config.ListMergeStrategy{
+				ListMapKeys: config.ListMapKeys{
+					Keys: []string{
+						"name",
+					},
+				},
+				MergeStrategy: config.ListTypeMap,
+			},
+		}
 	})
 
 	/*p.AddResourceConfigurator("azurerm_virtual_desktop_application", func(r *config.Resource) {

--- a/package/crds/network.azure.upbound.io_applicationgateways.yaml
+++ b/package/crds/network.azure.upbound.io_applicationgateways.yaml
@@ -4626,6 +4626,9 @@ spec:
                           type: object
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   frontendPort:
                     description: One or more frontend_port blocks as defined below.
                     items:
@@ -4728,6 +4731,9 @@ spec:
                           type: object
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   global:
                     description: A global block as defined below.
                     properties:
@@ -6051,6 +6057,9 @@ spec:
                           type: object
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   frontendPort:
                     description: One or more frontend_port blocks as defined below.
                     items:
@@ -6153,6 +6162,9 @@ spec:
                           type: object
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   global:
                     description: A global block as defined below.
                     properties:
@@ -7445,6 +7457,9 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   frontendPort:
                     description: One or more frontend_port blocks as defined below.
                     items:
@@ -7477,6 +7492,9 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   global:
                     description: A global block as defined below.
                     properties:


### PR DESCRIPTION
### Description of your changes

This change configures the list merge strategy for the application gateway on the known problematic arrays `frontendIpConfiguration` and `gatewayIpConfiguration`. This should allow the selectors being used normally as the array will not be replaced but merged instead. 
As the name has to be unique on the Application Gateway it serves well as an identifier.

Fixes #977

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested in our own setup, we have added a selector for subnet and public IP. 
The field managers will look like so allowing both reconcilers to do its job:
```yaml
apiVersion: network.azure.upbound.io/v1beta2
kind: ApplicationGateway
metadata:
  managedFields:
    - apiVersion: network.azure.upbound.io/v1beta2
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          f:forProvider:
            f:frontendIpConfiguration:
              k:{"name":"public-frontend-ip"}:
                .: {}
                f:name: {}
                f:publicIpAddressIdSelector:
                  f:matchLabels:
                    f:test: {}
            f:gatewayIpConfiguration:
              k:{"name":"gateway-ip"}:
                .: {}
                f:name: {}
                f:subnetIdSelector:
                  f:matchLabels:
                    f:test: {}
```

[contribution process]: https://git.io/fj2m9
