### PR TITLE
Fix subscriptionId ref extractor for ManagementGroupSubscriptionAssociation resource

### DIFF
--- a/apis/management/v1beta1/zz_generated.resolvers.go
+++ b/apis/management/v1beta1/zz_generated.resolvers.go
@@ -14,6 +14,7 @@ import (
 
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	rconfig "github.com/upbound/provider-azure/apis/rconfig"
+	management "github.com/upbound/provider-azure/config/management"
 	apisresolver "github.com/upbound/provider-azure/internal/apis"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -103,7 +104,7 @@ func (mg *ManagementGroupSubscriptionAssociation) ResolveReferences(ctx context.
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubscriptionID),
-			Extract:      rconfig.ExtractResourceID(),
+			Extract:      management.SubscriptionIDExtractor(),
 			Reference:    mg.Spec.ForProvider.SubscriptionIDRef,
 			Selector:     mg.Spec.ForProvider.SubscriptionIDSelector,
 			To:           reference.To{List: l, Managed: m},
@@ -141,7 +142,7 @@ func (mg *ManagementGroupSubscriptionAssociation) ResolveReferences(ctx context.
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.SubscriptionID),
-			Extract:      rconfig.ExtractResourceID(),
+			Extract:      management.SubscriptionIDExtractor(),
 			Reference:    mg.Spec.InitProvider.SubscriptionIDRef,
 			Selector:     mg.Spec.InitProvider.SubscriptionIDSelector,
 			To:           reference.To{List: l, Managed: m},

--- a/apis/management/v1beta1/zz_managementgroupsubscriptionassociation_types.go
+++ b/apis/management/v1beta1/zz_managementgroupsubscriptionassociation_types.go
@@ -30,7 +30,7 @@ type ManagementGroupSubscriptionAssociationInitParameters struct {
 
 	// The ID of the Subscription to be associated with the Management Group. Changing this forces a new Management to be created.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/azure/v1beta1.Subscription
-	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/config/management.SubscriptionIDExtractor()
 	SubscriptionID *string `json:"subscriptionId,omitempty" tf:"subscription_id,omitempty"`
 
 	// Reference to a Subscription in azure to populate subscriptionId.
@@ -72,7 +72,7 @@ type ManagementGroupSubscriptionAssociationParameters struct {
 
 	// The ID of the Subscription to be associated with the Management Group. Changing this forces a new Management to be created.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/azure/v1beta1.Subscription
-	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/apis/rconfig.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/config/management.SubscriptionIDExtractor()
 	// +kubebuilder:validation:Optional
 	SubscriptionID *string `json:"subscriptionId,omitempty" tf:"subscription_id,omitempty"`
 


### PR DESCRIPTION
### Description of your changes

This PR fixes the mentioned issue by adding the `SubscriptionIDExtractor` function.

Fixes https://github.com/crossplane-contrib/provider-upjet-azure/issues/960

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Manually tested.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
