### PR TITLE
Disable publicNetworkAccessEnabled for postgresql FlexibleServer example

### DIFF
--- a/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
+++ b/examples/dbforpostgresql/v1beta2/flexibleserver.yaml
@@ -22,6 +22,7 @@ spec:
       matchLabels:
         testing.upbound.io/example-name: example
     location: West Europe
+    publicNetworkAccessEnabled: false
     privateDnsZoneIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example


### PR DESCRIPTION


<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes
```
unexpected status 400 (400 Bad Request) with error: ConflictingPublicNetworkAccessAndVirtualNetworkConfiguration: Conflicting configuration is detected between Public Network Access and Virtual Network arguments. Public Network Access is not supported along with Virtual Network feature.
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

```
k get -f flexibleserver.yaml
NAME                                                      SYNCED   READY   EXTERNAL-NAME   AGE
flexibleserver.dbforpostgresql.azure.upbound.io/example   True     True    example         14m

NAME                                              SYNCED   READY   EXTERNAL-NAME                                 AGE
privatednszone.network.azure.upbound.io/example   True     True    example-upbound.postgres.database.azure.com   24m

NAME                                                                SYNCED   READY   EXTERNAL-NAME   AGE
privatednszonevirtualnetworklink.network.azure.upbound.io/example   True     True    example         24m

NAME                                     SYNCED   READY   EXTERNAL-NAME   AGE
resourcegroup.azure.upbound.io/example   True     True    example         24m

NAME                                      SYNCED   READY   EXTERNAL-NAME   AGE
subnet.network.azure.upbound.io/example   True     True    example         24m

NAME                                              SYNCED   READY   EXTERNAL-NAME   AGE
virtualnetwork.network.azure.upbound.io/example   True     True    example         24m
```
