### PR TITLE
Update go version to 1.23.8 [Security]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  GO_VERSION: "1.23.6"
+  GO_VERSION: "1.23.8"
 
 jobs:
   detect-noop:

--- a/.github/workflows/uptest-trigger.yml
+++ b/.github/workflows/uptest-trigger.yml
@@ -9,7 +9,7 @@ on:
     types: [created]
 
 env:
-  GO_VERSION: "1.23.6"
+  GO_VERSION: "1.23.8"
 
 jobs:
   check-permissions:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 # correctly.
 export GOPRIVATE = github.com/upbound/*
 
-GO_REQUIRED_VERSION ?= 1.21
+GO_REQUIRED_VERSION ?= 1.23
 # GOLANGCILINT_VERSION is inherited from build submodule by default.
 # Uncomment below if you need to override the version.
 # GOLANGCILINT_VERSION ?= 1.55.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/upbound/provider-azure
 
-go 1.23.6
+go 1.23.8
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR updates the go version to 1.23.8 for the following CVE:
```
NAME                 INSTALLED  FIXED-IN        TYPE       VULNERABILITY        SEVERITY
stdlib               go1.23.6   1.23.8, 1.24.2  go-module  CVE-2025-22871       Critical
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

https://github.com/crossplane-contrib/provider-upjet-azure/actions/runs/14892769840

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
