### PR TITLE
Disable lateinit and add descriptions for deprecated fields in the subnet.network resource

### DIFF
--- a/apis/network/v1beta1/zz_subnet_terraformed.go
+++ b/apis/network/v1beta1/zz_subnet_terraformed.go
@@ -118,6 +118,9 @@ func (tr *Subnet) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("EnforcePrivateLinkEndpointNetworkPolicies"))
+	opts = append(opts, resource.WithNameFilter("EnforcePrivateLinkServiceNetworkPolicies"))
+	opts = append(opts, resource.WithNameFilter("PrivateEndpointNetworkPoliciesEnabled"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/network/v1beta1/zz_subnet_types.go
+++ b/apis/network/v1beta1/zz_subnet_types.go
@@ -82,13 +82,16 @@ type SubnetInitParameters struct {
 	// One or more delegation blocks as defined below.
 	Delegation []DelegationInitParameters `json:"delegation,omitempty" tf:"delegation,omitempty"`
 
+	// `enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies.
 	EnforcePrivateLinkEndpointNetworkPolicies *bool `json:"enforcePrivateLinkEndpointNetworkPolicies,omitempty" tf:"enforce_private_link_endpoint_network_policies,omitempty"`
 
+	// `enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.
 	EnforcePrivateLinkServiceNetworkPolicies *bool `json:"enforcePrivateLinkServiceNetworkPolicies,omitempty" tf:"enforce_private_link_service_network_policies,omitempty"`
 
 	// Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Disabled.
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty" tf:"private_endpoint_network_policies,omitempty"`
 
+	// `privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies.
 	PrivateEndpointNetworkPoliciesEnabled *bool `json:"privateEndpointNetworkPoliciesEnabled,omitempty" tf:"private_endpoint_network_policies_enabled,omitempty"`
 
 	// Enable or Disable network policies for the private link service on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy. Defaults to true.
@@ -114,8 +117,10 @@ type SubnetObservation struct {
 	// One or more delegation blocks as defined below.
 	Delegation []DelegationObservation `json:"delegation,omitempty" tf:"delegation,omitempty"`
 
+	// `enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies.
 	EnforcePrivateLinkEndpointNetworkPolicies *bool `json:"enforcePrivateLinkEndpointNetworkPolicies,omitempty" tf:"enforce_private_link_endpoint_network_policies,omitempty"`
 
+	// `enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.
 	EnforcePrivateLinkServiceNetworkPolicies *bool `json:"enforcePrivateLinkServiceNetworkPolicies,omitempty" tf:"enforce_private_link_service_network_policies,omitempty"`
 
 	// The subnet ID.
@@ -124,6 +129,7 @@ type SubnetObservation struct {
 	// Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Disabled.
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty" tf:"private_endpoint_network_policies,omitempty"`
 
+	// `privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies.
 	PrivateEndpointNetworkPoliciesEnabled *bool `json:"privateEndpointNetworkPoliciesEnabled,omitempty" tf:"private_endpoint_network_policies_enabled,omitempty"`
 
 	// Enable or Disable network policies for the private link service on the subnet. Setting this to true will Enable the policy and setting this to false will Disable the policy. Defaults to true.
@@ -158,9 +164,11 @@ type SubnetParameters struct {
 	// +kubebuilder:validation:Optional
 	Delegation []DelegationParameters `json:"delegation,omitempty" tf:"delegation,omitempty"`
 
+	// `enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies.
 	// +kubebuilder:validation:Optional
 	EnforcePrivateLinkEndpointNetworkPolicies *bool `json:"enforcePrivateLinkEndpointNetworkPolicies,omitempty" tf:"enforce_private_link_endpoint_network_policies,omitempty"`
 
+	// `enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.
 	// +kubebuilder:validation:Optional
 	EnforcePrivateLinkServiceNetworkPolicies *bool `json:"enforcePrivateLinkServiceNetworkPolicies,omitempty" tf:"enforce_private_link_service_network_policies,omitempty"`
 
@@ -168,6 +176,7 @@ type SubnetParameters struct {
 	// +kubebuilder:validation:Optional
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty" tf:"private_endpoint_network_policies,omitempty"`
 
+	// `privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies.
 	// +kubebuilder:validation:Optional
 	PrivateEndpointNetworkPoliciesEnabled *bool `json:"privateEndpointNetworkPoliciesEnabled,omitempty" tf:"private_endpoint_network_policies_enabled,omitempty"`
 

--- a/apis/network/v1beta2/zz_subnet_terraformed.go
+++ b/apis/network/v1beta2/zz_subnet_terraformed.go
@@ -118,6 +118,9 @@ func (tr *Subnet) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("EnforcePrivateLinkEndpointNetworkPolicies"))
+	opts = append(opts, resource.WithNameFilter("EnforcePrivateLinkServiceNetworkPolicies"))
+	opts = append(opts, resource.WithNameFilter("PrivateEndpointNetworkPoliciesEnabled"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/network/v1beta2/zz_subnet_types.go
+++ b/apis/network/v1beta2/zz_subnet_types.go
@@ -82,13 +82,16 @@ type SubnetInitParameters struct {
 	// One or more delegation blocks as defined below.
 	Delegation []DelegationInitParameters `json:"delegation,omitempty" tf:"delegation,omitempty"`
 
+	// `enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies.
 	EnforcePrivateLinkEndpointNetworkPolicies *bool `json:"enforcePrivateLinkEndpointNetworkPolicies,omitempty" tf:"enforce_private_link_endpoint_network_policies,omitempty"`
 
+	// `enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.
 	EnforcePrivateLinkServiceNetworkPolicies *bool `json:"enforcePrivateLinkServiceNetworkPolicies,omitempty" tf:"enforce_private_link_service_network_policies,omitempty"`
 
 	// Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Disabled.
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty" tf:"private_endpoint_network_policies,omitempty"`
 
+	// `privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies.
 	PrivateEndpointNetworkPoliciesEnabled *bool `json:"privateEndpointNetworkPoliciesEnabled,omitempty" tf:"private_endpoint_network_policies_enabled,omitempty"`
 
 	// Enable or Disable network policies for the private link service on the subnet. Defaults to true.
@@ -114,8 +117,10 @@ type SubnetObservation struct {
 	// One or more delegation blocks as defined below.
 	Delegation []DelegationObservation `json:"delegation,omitempty" tf:"delegation,omitempty"`
 
+	// `enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies.
 	EnforcePrivateLinkEndpointNetworkPolicies *bool `json:"enforcePrivateLinkEndpointNetworkPolicies,omitempty" tf:"enforce_private_link_endpoint_network_policies,omitempty"`
 
+	// `enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.
 	EnforcePrivateLinkServiceNetworkPolicies *bool `json:"enforcePrivateLinkServiceNetworkPolicies,omitempty" tf:"enforce_private_link_service_network_policies,omitempty"`
 
 	// The subnet ID.
@@ -124,6 +129,7 @@ type SubnetObservation struct {
 	// Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Disabled.
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty" tf:"private_endpoint_network_policies,omitempty"`
 
+	// `privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies.
 	PrivateEndpointNetworkPoliciesEnabled *bool `json:"privateEndpointNetworkPoliciesEnabled,omitempty" tf:"private_endpoint_network_policies_enabled,omitempty"`
 
 	// Enable or Disable network policies for the private link service on the subnet. Defaults to true.
@@ -158,9 +164,11 @@ type SubnetParameters struct {
 	// +kubebuilder:validation:Optional
 	Delegation []DelegationParameters `json:"delegation,omitempty" tf:"delegation,omitempty"`
 
+	// `enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies.
 	// +kubebuilder:validation:Optional
 	EnforcePrivateLinkEndpointNetworkPolicies *bool `json:"enforcePrivateLinkEndpointNetworkPolicies,omitempty" tf:"enforce_private_link_endpoint_network_policies,omitempty"`
 
+	// `enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.
 	// +kubebuilder:validation:Optional
 	EnforcePrivateLinkServiceNetworkPolicies *bool `json:"enforcePrivateLinkServiceNetworkPolicies,omitempty" tf:"enforce_private_link_service_network_policies,omitempty"`
 
@@ -168,6 +176,7 @@ type SubnetParameters struct {
 	// +kubebuilder:validation:Optional
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty" tf:"private_endpoint_network_policies,omitempty"`
 
+	// `privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies.
 	// +kubebuilder:validation:Optional
 	PrivateEndpointNetworkPoliciesEnabled *bool `json:"privateEndpointNetworkPoliciesEnabled,omitempty" tf:"private_endpoint_network_policies_enabled,omitempty"`
 

--- a/config/network/config.go
+++ b/config/network/config.go
@@ -538,11 +538,17 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_subnet", func(r *config.Resource) {
 		r.Kind = "Subnet"
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"address_prefix"},
+			IgnoredFields: []string{"address_prefix",
+				"enforce_private_link_endpoint_network_policies",
+				"private_endpoint_network_policies_enabled",
+				"enforce_private_link_service_network_policies"},
 		}
 		r.References["virtual_network_name"] = config.Reference{
 			TerraformName: "azurerm_virtual_network",
 		}
+		r.TerraformResource.Schema["enforce_private_link_endpoint_network_policies"].Description = "`enforcePrivateLinkEndpointNetworkPolicies` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled, privateEndpointNetworkPolicies."
+		r.TerraformResource.Schema["private_endpoint_network_policies_enabled"].Description = "`privateEndpointNetworkPoliciesEnabled` will be removed in favour of the property `privateEndpointNetworkPolicies` in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies, privateEndpointNetworkPolicies."
+		r.TerraformResource.Schema["enforce_private_link_service_network_policies"].Description = "`enforcePrivateLinkServiceNetworkPolicies` will be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled` in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled."
 	})
 
 	p.AddResourceConfigurator("azurerm_subnet_nat_gateway_association", func(r *config.Resource) {

--- a/package/crds/network.azure.upbound.io_subnets.yaml
+++ b/package/crds/network.azure.upbound.io_subnets.yaml
@@ -947,8 +947,15 @@ spec:
                       type: object
                     type: array
                   enforcePrivateLinkEndpointNetworkPolicies:
+                    description: '`enforcePrivateLinkEndpointNetworkPolicies` will
+                      be removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   enforcePrivateLinkServiceNetworkPolicies:
+                    description: '`enforcePrivateLinkServiceNetworkPolicies` will
+                      be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled`
+                      in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.'
                     type: boolean
                   privateEndpointNetworkPolicies:
                     description: Enable or Disable network policies for the private
@@ -957,6 +964,10 @@ spec:
                       to Disabled.
                     type: string
                   privateEndpointNetworkPoliciesEnabled:
+                    description: '`privateEndpointNetworkPoliciesEnabled` will be
+                      removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   privateLinkServiceNetworkPoliciesEnabled:
                     description: Enable or Disable network policies for the private
@@ -1225,8 +1236,15 @@ spec:
                       type: object
                     type: array
                   enforcePrivateLinkEndpointNetworkPolicies:
+                    description: '`enforcePrivateLinkEndpointNetworkPolicies` will
+                      be removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   enforcePrivateLinkServiceNetworkPolicies:
+                    description: '`enforcePrivateLinkServiceNetworkPolicies` will
+                      be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled`
+                      in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.'
                     type: boolean
                   privateEndpointNetworkPolicies:
                     description: Enable or Disable network policies for the private
@@ -1235,6 +1253,10 @@ spec:
                       to Disabled.
                     type: string
                   privateEndpointNetworkPoliciesEnabled:
+                    description: '`privateEndpointNetworkPoliciesEnabled` will be
+                      removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   privateLinkServiceNetworkPoliciesEnabled:
                     description: Enable or Disable network policies for the private
@@ -1505,8 +1527,15 @@ spec:
                       type: object
                     type: array
                   enforcePrivateLinkEndpointNetworkPolicies:
+                    description: '`enforcePrivateLinkEndpointNetworkPolicies` will
+                      be removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   enforcePrivateLinkServiceNetworkPolicies:
+                    description: '`enforcePrivateLinkServiceNetworkPolicies` will
+                      be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled`
+                      in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.'
                     type: boolean
                   id:
                     description: The subnet ID.
@@ -1518,6 +1547,10 @@ spec:
                       to Disabled.
                     type: string
                   privateEndpointNetworkPoliciesEnabled:
+                    description: '`privateEndpointNetworkPoliciesEnabled` will be
+                      removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   privateLinkServiceNetworkPoliciesEnabled:
                     description: Enable or Disable network policies for the private

--- a/package/crds/network.azure.upbound.io_subnets.yaml
+++ b/package/crds/network.azure.upbound.io_subnets.yaml
@@ -147,8 +147,15 @@ spec:
                       type: object
                     type: array
                   enforcePrivateLinkEndpointNetworkPolicies:
+                    description: '`enforcePrivateLinkEndpointNetworkPolicies` will
+                      be removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   enforcePrivateLinkServiceNetworkPolicies:
+                    description: '`enforcePrivateLinkServiceNetworkPolicies` will
+                      be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled`
+                      in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.'
                     type: boolean
                   privateEndpointNetworkPolicies:
                     description: Enable or Disable network policies for the private
@@ -157,6 +164,10 @@ spec:
                       to Disabled.
                     type: string
                   privateEndpointNetworkPoliciesEnabled:
+                    description: '`privateEndpointNetworkPoliciesEnabled` will be
+                      removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   privateLinkServiceNetworkPoliciesEnabled:
                     description: Enable or Disable network policies for the private
@@ -429,8 +440,15 @@ spec:
                       type: object
                     type: array
                   enforcePrivateLinkEndpointNetworkPolicies:
+                    description: '`enforcePrivateLinkEndpointNetworkPolicies` will
+                      be removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   enforcePrivateLinkServiceNetworkPolicies:
+                    description: '`enforcePrivateLinkServiceNetworkPolicies` will
+                      be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled`
+                      in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.'
                     type: boolean
                   privateEndpointNetworkPolicies:
                     description: Enable or Disable network policies for the private
@@ -439,6 +457,10 @@ spec:
                       to Disabled.
                     type: string
                   privateEndpointNetworkPoliciesEnabled:
+                    description: '`privateEndpointNetworkPoliciesEnabled` will be
+                      removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   privateLinkServiceNetworkPoliciesEnabled:
                     description: Enable or Disable network policies for the private
@@ -715,8 +737,15 @@ spec:
                       type: object
                     type: array
                   enforcePrivateLinkEndpointNetworkPolicies:
+                    description: '`enforcePrivateLinkEndpointNetworkPolicies` will
+                      be removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with privateEndpointNetworkPoliciesEnabled,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   enforcePrivateLinkServiceNetworkPolicies:
+                    description: '`enforcePrivateLinkServiceNetworkPolicies` will
+                      be removed in favour of the property `privateLinkServiceNetworkPoliciesEnabled`
+                      in version 2.0 of the provider. Conflicts with privateLinkServiceNetworkPoliciesEnabled.'
                     type: boolean
                   id:
                     description: The subnet ID.
@@ -728,6 +757,10 @@ spec:
                       to Disabled.
                     type: string
                   privateEndpointNetworkPoliciesEnabled:
+                    description: '`privateEndpointNetworkPoliciesEnabled` will be
+                      removed in favour of the property `privateEndpointNetworkPolicies`
+                      in version 2.0 of the provider. Conflicts with enforcePrivateLinkEndpointNetworkPolicies,
+                      privateEndpointNetworkPolicies.'
                     type: boolean
                   privateLinkServiceNetworkPoliciesEnabled:
                     description: Enable or Disable network policies for the private


### PR DESCRIPTION
### Description of your changes

Disables lateinit and adds descriptions for deprecated fields in the subnet.network resource:

- `enforcePrivateLinkEndpointNetworkPolicies `
- `enforcePrivateLinkServiceNetworkPolicies `
- `privateEndpointNetworkPoliciesEnabled `

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Manually tested with the following YAML. After the resources were created, the deprecated fields were removed by editing the subnet MR and the update cycle ended. 
- [subnet-with-private-endpoint.txt](https://github.com/user-attachments/files/20440536/subnet-with-private-endpoint.txt)
- [subnet-get-o-yaml.txt](https://github.com/user-attachments/files/20440562/subnet-get-o-yaml.txt)



[contribution process]: https://git.io/fj2m9
