### PR TITLE
fix: add custom ExternalName handling for azurerm_policy_definition

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2130,16 +2130,12 @@ func policyDefinitionExternalName() config.ExternalName {
 		},
 
 		GetExternalNameFn: func(tfstate map[string]interface{}) (string, error) {
-			idRaw, ok := tfstate["id"]
+			id, ok := tfstate["id"]
 			if !ok {
 				return "", errors.New("cannot find 'id' in tfstate")
 			}
-			id, ok := idRaw.(string)
-			if !ok || id == "" {
-				return "", errors.New("invalid or empty 'id' in tfstate")
-			}
 
-			parts := strings.Split(id, "/")
+			parts := strings.Split(id.(string), "/")
 			if len(parts) < 2 {
 				return "", errors.New("unexpected format for 'id' in tfstate")
 			}

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crossplane/upjet/pkg/config"
+	"github.com/crossplane/upjet/pkg/terraform"
 )
 
 // TerraformPluginSDKExternalNameConfigs contains all external name configurations
@@ -2150,7 +2151,7 @@ func policyDefinitionExternalName() config.ExternalName {
 			}
 
 			// Subscription level
-			conf, ok := terraformProviderConfig["configuration"].(map[string]any)
+			conf, ok := terraformProviderConfig["configuration"].(terraform.ProviderConfiguration)
 			if !ok {
 				return "", errors.New("terraform provider configuration is not a map")
 			}

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2161,7 +2161,10 @@ func policyDefinitionExternalName() config.ExternalName {
 
 			return fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/policyDefinitions/%s", subID, externalName), nil
 		},
-		OmittedFields: []string{"name"},
+		OmittedFields: []string{
+			"name",
+			"name_prefix",
+		},
 	}
 }
 

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2125,8 +2125,8 @@ func mongoDatabaseBasedId(nameField string, objectType string) config.ExternalNa
 //   - /providers/Microsoft.Management/managementgroups/<MGMT_GROUP_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
 func policyDefinitionExternalName() config.ExternalName {
 	return config.ExternalName{
-		SetIdentifierArgumentFn: func(base map[string]any, name string) {
-			base["name"] = name
+		SetIdentifierArgumentFn: func(base map[string]any, externalName string) {
+			base["name"] = externalName
 		},
 
 		GetExternalNameFn: func(tfstate map[string]interface{}) (string, error) {

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crossplane/upjet/pkg/config"
-	"github.com/crossplane/upjet/pkg/terraform"
 )
 
 // TerraformPluginSDKExternalNameConfigs contains all external name configurations
@@ -2151,7 +2150,7 @@ func policyDefinitionExternalName() config.ExternalName {
 			}
 
 			// Subscription level
-			conf, ok := terraformProviderConfig["configuration"].(terraform.ProviderConfiguration)
+			conf, ok := terraformProviderConfig["configuration"].(map[string]any)
 			if !ok {
 				return "", errors.New("terraform provider configuration is not a map")
 			}

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2135,7 +2135,7 @@ func policyDefinitionExternalName() config.ExternalName {
 			}
 
 			parts := strings.Split(id.(string), "/")
-			if len(parts) != 6 || len(parts) != 8 {
+			if len(parts) != 7 && len(parts) != 9 {
 				return "", errors.New("unexpected format for 'id' in tfstate")
 			}
 			return parts[len(parts)-1], nil

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crossplane/upjet/pkg/config"
+	"github.com/crossplane/upjet/pkg/terraform"
 )
 
 // TerraformPluginSDKExternalNameConfigs contains all external name configurations
@@ -882,9 +883,11 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.TimeSeriesInsights/environments/example
 	"azurerm_iot_time_series_insights_standard_environment": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/resourceGroups/{{ .parameters.resource_group_name }}/providers/Microsoft.TimeSeriesInsights/environments/{{ .external_name }}"),
 
-	// azurerm_policy_definition can be imported
-	// azurerm_policy_definition.examplePolicy /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
-	"azurerm_policy_definition": config.TemplatedStringAsIdentifier("name", "/subscriptions/{{ .setup.configuration.subscription_id }}/providers/Microsoft.Authorization/policyDefinitions/{{ .external_name }}"),
+	// azurerm_policy_definition can be imported at subscription or management group level
+	// Example IDs:
+	//	/subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
+	//	/providers/Microsoft.Management/managementgroups/<MGMT_GROUP_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
+	"azurerm_policy_definition": policyDefinitionExternalName(),
 
 	// alertsmanagement
 	//
@@ -2109,6 +2112,61 @@ func mongoDatabaseBasedId(nameField string, objectType string) config.ExternalNa
 
 			return strings.Join(append(accountId, objectType, databaseName+"."+externalName), "/"), nil
 		},
+	}
+}
+
+// policyDefinitionExternalName returns a custom ExternalName configuration
+// for azurerm_policy_definition. It supports both subscription and management
+// group level policy definitions by constructing and parsing the appropriate
+// Azure resource ID formats.
+//
+// Supported ID formats:
+//   - /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
+//   - /providers/Microsoft.Management/managementgroups/<MGMT_GROUP_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
+func policyDefinitionExternalName() config.ExternalName {
+	return config.ExternalName{
+		SetIdentifierArgumentFn: func(base map[string]any, name string) {
+			base["name"] = name
+		},
+
+		GetExternalNameFn: func(tfstate map[string]interface{}) (string, error) {
+			idRaw, ok := tfstate["id"]
+			if !ok {
+				return "", errors.New("cannot find 'id' in tfstate")
+			}
+			id, ok := idRaw.(string)
+			if !ok || id == "" {
+				return "", errors.New("invalid or empty 'id' in tfstate")
+			}
+
+			parts := strings.Split(id, "/")
+			if len(parts) < 2 {
+				return "", errors.New("unexpected format for 'id' in tfstate")
+			}
+			return parts[len(parts)-1], nil
+		},
+
+		GetIDFn: func(_ context.Context, externalName string, parameters map[string]interface{}, terraformProviderConfig map[string]interface{}) (string, error) {
+			// Management group level
+			if mg, ok := parameters["management_group_id"]; ok {
+				if mgStr, ok := mg.(string); ok && mgStr != "" {
+					return fmt.Sprintf("%s/providers/Microsoft.Authorization/policyDefinitions/%s", mgStr, externalName), nil
+				}
+			}
+
+			// Subscription level
+			conf, ok := terraformProviderConfig["configuration"].(terraform.ProviderConfiguration)
+			if !ok {
+				return "", errors.New("terraform provider configuration is not a map")
+			}
+			subID, ok := conf["subscription_id"].(string)
+			if !ok || subID == "" {
+				return "", errors.New("unable to extract 'subscription_id' from provider configuration")
+			}
+
+			return fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/policyDefinitions/%s", subID, externalName), nil
+		},
+		OmittedFields: []string{"name"},
 	}
 }
 

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2136,7 +2136,7 @@ func policyDefinitionExternalName() config.ExternalName {
 			}
 
 			parts := strings.Split(id.(string), "/")
-			if len(parts) < 2 {
+			if len(parts) != 6 || len(parts) != 8 {
 				return "", errors.New("unexpected format for 'id' in tfstate")
 			}
 			return parts[len(parts)-1], nil


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
Implements a custom ExternalName configuration for the `azurerm_policy_definition` resource to support both **subscription-level** and **management group-level** policy definitions.

This ensures the correct construction of resource IDs in the format:

  - `/subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>`
  - `/providers/Microsoft.Management/managementgroups/<MGMT_GROUP_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>`
<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes https://github.com/crossplane-contrib/provider-upjet-azure/issues/982

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Created `PolicyDefinition` on subscription and management levels
- Ensured they both successfully reconciled and appeared in Azure
- Deleted both resources
- Ensured both are deleted in Azure

[contribution process]: https://git.io/fj2m9
