### PR TITLE
Add round-robin service principal authentication to mitigate Azure ARM throttling

### DIFF
--- a/internal/clients/azure.go
+++ b/internal/clients/azure.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/go-logr/logr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tfsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -137,10 +136,6 @@ func spAuth(ctx context.Context, pcSpec *namespacedv1beta1.ProviderConfigSpec, p
 		// Round-robin selection
 		index := atomic.AddUint64(&servicePrincipalCounter, 1) % uint64(len(servicePrincipals))
 		azureCreds := servicePrincipals[index]
-		// Log selected service principal with logr if available in context
-		log := logr.FromContextOrDiscard(ctx)
-		log.Info("Selected service principal", "index", index,
-			"clientId", azureCreds[keyAzureClientID])
 		return configureSpCredentials(azureCreds, pcSpec, ps)
 	}
 


### PR DESCRIPTION
### Azure Resource Manager (ARM) Throttling

To mitigate ARM rate limits when reconciling many resources, this PR adds support for distributing requests across multiple service principals via round-robin selection.

- **Per security principal**: Limits apply per service principal or user and are scoped to subscription ID or tenant ID.
- **Default limits**: ~12,000 read operations/hour/subscription and ~1,200 write operations/hour/subscription.
- **Per ARM instance**: Limits are applied per ARM instance across regions, so effective headroom can be higher in practice.

By rotating among multiple service principals, the effective throughput increases and the likelihood of throttling (HTTP 429) is reduced.

### Description of your changes

This PR implements round-robin service principal selection for Azure provider authentication to help distribute load and avoid rate limiting when using multiple service principals.

**Changes:**
- Added support for multiple service principals in JSON array format in credentials secret
- Implemented atomic counter-based round-robin selection in `spAuth` function
- Maintains backward compatibility with single service principal format

**Usage:**
Users can now provide multiple service principals in their credentials secret as a JSON array:
```json
[
  {
    "subscriptionId": "sub-id",
    "tenantId": "tenant-id",
    "clientId": "client-1",
    "clientSecret": "secret-1"
  },
  {
    "subscriptionId": "sub-id",
    "tenantId": "tenant-id",
    "clientId": "client-2",
    "clientSecret": "secret-2"
  }
]
```
```
 k get resourcegroups.azure.upbound.io
NAME             SYNCED   READY   EXTERNAL-NAME    AGE
test-multi-sps   True     True    test-multi-sps   4m37s
```

Each reconciliation will use the next service principal in sequence, cycling back to the first after reaching the end.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- **Backward compatibility**: Verified single service principal format still works
- **Integration testing**: Tested with multiple Azure resources to confirm different SPs are used
- **Secret formats**: Validated both existing object-style secret format and new JSON list format - managed resources were successfully created with both approaches.
- 
The implementation uses `sync/atomic` for thread-safe counter increments and maintains the existing authentication flow while adding round-robin selection when multiple service principals are detected.

