### PR TITLE
chore(ci): update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           make schema-version-diff
 
   lint:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
@@ -155,7 +155,7 @@ jobs:
           path: _output/skipped_resources.csv
 
   unit-tests:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
@@ -185,7 +185,7 @@ jobs:
         run: make -j2 test
 
   local-deploy:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
     steps:

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -35,7 +35,7 @@ jobs:
       version: ${{ github.event.inputs.version }}
       go-version: ${{ github.event.inputs.go-version }}
       cleanup-disk: true
-      runs-on: ubuntu-latest-16-cores
+      runs-on: oracle-vm-16cpu-64gb-x86-64
     secrets:
       GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
       XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
