### PR TITLE
Ignore lateinitialize for node_count field in KubernetesClusterNodePool resource

### DIFF
--- a/apis/cluster/containerservice/v1beta1/zz_kubernetesclusternodepool_terraformed.go
+++ b/apis/cluster/containerservice/v1beta1/zz_kubernetesclusternodepool_terraformed.go
@@ -118,6 +118,7 @@ func (tr *KubernetesClusterNodePool) LateInitialize(attrs []byte) (bool, error) 
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/containerservice/v1beta2/zz_kubernetesclusternodepool_terraformed.go
+++ b/apis/cluster/containerservice/v1beta2/zz_kubernetesclusternodepool_terraformed.go
@@ -118,6 +118,7 @@ func (tr *KubernetesClusterNodePool) LateInitialize(attrs []byte) (bool, error) 
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/containerservice/v1beta1/zz_kubernetesclusternodepool_terraformed.go
+++ b/apis/namespaced/containerservice/v1beta1/zz_kubernetesclusternodepool_terraformed.go
@@ -118,6 +118,7 @@ func (tr *KubernetesClusterNodePool) LateInitialize(attrs []byte) (bool, error) 
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("NodeCount"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/cluster/containerservice/config.go
+++ b/config/cluster/containerservice/config.go
@@ -93,6 +93,9 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_kubernetes_cluster",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"node_count"},
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_kubernetes_cluster_extension", func(r *config.Resource) {

--- a/config/namespaced/containerservice/config.go
+++ b/config/namespaced/containerservice/config.go
@@ -93,6 +93,9 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_kubernetes_cluster",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"node_count"},
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_kubernetes_cluster_extension", func(r *config.Resource) {


### PR DESCRIPTION
### Description of your changes

Ignore lateinitialize for the node_count field in KubernetesClusterNodePool resource

Fixes: https://github.com/crossplane-contrib/provider-upjet-azure/issues/1010

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
