### PR TITLE
Add missing resource refs in APIOperationPolicy

### DIFF
--- a/apis/cluster/apimanagement/v1beta1/zz_apioperationpolicy_types.go
+++ b/apis/cluster/apimanagement/v1beta1/zz_apioperationpolicy_types.go
@@ -49,30 +49,28 @@ type APIOperationPolicyObservation struct {
 type APIOperationPolicyParameters struct {
 
 	// The name of the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cluster/apimanagement/v1beta2.APIOperation
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("api_management_name",false)
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cluster/apimanagement/v1beta2.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a APIOperation in apimanagement to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.Reference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a APIOperation in apimanagement to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.Selector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The name of the API within the API Management Service where the Operation exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cluster/apimanagement/v1beta2.APIOperation
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("api_name",false)
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/cluster/apimanagement/v1beta2.API
 	// +kubebuilder:validation:Optional
 	APIName *string `json:"apiName,omitempty" tf:"api_name,omitempty"`
 
-	// Reference to a APIOperation in apimanagement to populate apiName.
+	// Reference to a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameRef *v1.Reference `json:"apiNameRef,omitempty" tf:"-"`
 
-	// Selector for a APIOperation in apimanagement to populate apiName.
+	// Selector for a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameSelector *v1.Selector `json:"apiNameSelector,omitempty" tf:"-"`
 

--- a/apis/cluster/apimanagement/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/apimanagement/v1beta1/zz_generated.resolvers.go
@@ -262,14 +262,14 @@ func (mg *APIOperationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	var rsp reference.ResolutionResponse
 	var err error
 	{
-		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.upbound.io", "v1beta2", "APIOperation", "APIOperationList")
+		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.upbound.io", "v1beta2", "Management", "ManagementList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 		}
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.APIManagementName),
-			Extract:      resource.ExtractParamPath("api_management_name", false),
+			Extract:      reference.ExternalName(),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.ForProvider.APIManagementNameRef,
 			Selector:     mg.Spec.ForProvider.APIManagementNameSelector,
@@ -282,14 +282,14 @@ func (mg *APIOperationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	mg.Spec.ForProvider.APIManagementName = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.APIManagementNameRef = rsp.ResolvedReference
 	{
-		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.upbound.io", "v1beta2", "APIOperation", "APIOperationList")
+		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.upbound.io", "v1beta2", "API", "APIList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 		}
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.APIName),
-			Extract:      resource.ExtractParamPath("api_name", false),
+			Extract:      reference.ExternalName(),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.ForProvider.APINameRef,
 			Selector:     mg.Spec.ForProvider.APINameSelector,

--- a/apis/namespaced/apimanagement/v1beta1/zz_apioperationpolicy_types.go
+++ b/apis/namespaced/apimanagement/v1beta1/zz_apioperationpolicy_types.go
@@ -50,30 +50,28 @@ type APIOperationPolicyObservation struct {
 type APIOperationPolicyParameters struct {
 
 	// The name of the API Management Service. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/namespaced/apimanagement/v1beta1.APIOperation
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("api_management_name",false)
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/namespaced/apimanagement/v1beta1.Management
 	// +kubebuilder:validation:Optional
 	APIManagementName *string `json:"apiManagementName,omitempty" tf:"api_management_name,omitempty"`
 
-	// Reference to a APIOperation in apimanagement to populate apiManagementName.
+	// Reference to a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameRef *v1.NamespacedReference `json:"apiManagementNameRef,omitempty" tf:"-"`
 
-	// Selector for a APIOperation in apimanagement to populate apiManagementName.
+	// Selector for a Management in apimanagement to populate apiManagementName.
 	// +kubebuilder:validation:Optional
 	APIManagementNameSelector *v1.NamespacedSelector `json:"apiManagementNameSelector,omitempty" tf:"-"`
 
 	// The name of the API within the API Management Service where the Operation exists. Changing this forces a new resource to be created.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/namespaced/apimanagement/v1beta1.APIOperation
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("api_name",false)
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/apis/namespaced/apimanagement/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIName *string `json:"apiName,omitempty" tf:"api_name,omitempty"`
 
-	// Reference to a APIOperation in apimanagement to populate apiName.
+	// Reference to a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameRef *v1.NamespacedReference `json:"apiNameRef,omitempty" tf:"-"`
 
-	// Selector for a APIOperation in apimanagement to populate apiName.
+	// Selector for a API in apimanagement to populate apiName.
 	// +kubebuilder:validation:Optional
 	APINameSelector *v1.NamespacedSelector `json:"apiNameSelector,omitempty" tf:"-"`
 

--- a/apis/namespaced/apimanagement/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/apimanagement/v1beta1/zz_generated.resolvers.go
@@ -262,14 +262,14 @@ func (mg *APIOperationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	var rsp reference.NamespacedResolutionResponse
 	var err error
 	{
-		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.m.upbound.io", "v1beta1", "APIOperation", "APIOperationList")
+		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.m.upbound.io", "v1beta1", "Management", "ManagementList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 		}
 
 		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.APIManagementName),
-			Extract:      resource.ExtractParamPath("api_management_name", false),
+			Extract:      reference.ExternalName(),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.ForProvider.APIManagementNameRef,
 			Selector:     mg.Spec.ForProvider.APIManagementNameSelector,
@@ -282,14 +282,14 @@ func (mg *APIOperationPolicy) ResolveReferences(ctx context.Context, c client.Re
 	mg.Spec.ForProvider.APIManagementName = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.APIManagementNameRef = rsp.ResolvedReference
 	{
-		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.m.upbound.io", "v1beta1", "APIOperation", "APIOperationList")
+		m, l, err = apisresolver.GetManagedResource("apimanagement.azure.m.upbound.io", "v1beta1", "API", "APIList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 		}
 
 		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.APIName),
-			Extract:      resource.ExtractParamPath("api_name", false),
+			Extract:      reference.ExternalName(),
 			Namespace:    mg.GetNamespace(),
 			Reference:    mg.Spec.ForProvider.APINameRef,
 			Selector:     mg.Spec.ForProvider.APINameSelector,

--- a/config/cluster/apimanagement/config.go
+++ b/config/cluster/apimanagement/config.go
@@ -115,6 +115,17 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_api_management_group",
 		}
 	})
+	p.AddResourceConfigurator("azurerm_api_management_api_operation_policy", func(r *config.Resource) {
+		r.References["api_name"] = config.Reference{
+			TerraformName: "azurerm_api_management_api",
+		}
+		r.References["api_management_name"] = config.Reference{
+			TerraformName: "azurerm_api_management",
+		}
+		r.References["operation_id"] = config.Reference{
+			TerraformName: "azurerm_api_management_api_operation",
+		}
+	})
 }
 
 func apiIdCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, resourceConfig *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo

--- a/config/namespaced/apimanagement/config.go
+++ b/config/namespaced/apimanagement/config.go
@@ -115,6 +115,17 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_api_management_group",
 		}
 	})
+	p.AddResourceConfigurator("azurerm_api_management_api_operation_policy", func(r *config.Resource) {
+		r.References["api_name"] = config.Reference{
+			TerraformName: "azurerm_api_management_api",
+		}
+		r.References["api_management_name"] = config.Reference{
+			TerraformName: "azurerm_api_management",
+		}
+		r.References["operation_id"] = config.Reference{
+			TerraformName: "azurerm_api_management_api_operation",
+		}
+	})
 }
 
 func apiIdCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, resourceConfig *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo

--- a/package/crds/apimanagement.azure.m.upbound.io_apioperationpolicies.yaml
+++ b/package/crds/apimanagement.azure.m.upbound.io_apioperationpolicies.yaml
@@ -64,7 +64,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a APIOperation in apimanagement to populate
+                    description: Reference to a Management in apimanagement to populate
                       apiManagementName.
                     properties:
                       name:
@@ -102,7 +102,7 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a APIOperation in apimanagement to populate
+                    description: Selector for a Management in apimanagement to populate
                       apiManagementName.
                     properties:
                       matchControllerRef:
@@ -151,8 +151,7 @@ spec:
                       to be created.
                     type: string
                   apiNameRef:
-                    description: Reference to a APIOperation in apimanagement to populate
-                      apiName.
+                    description: Reference to a API in apimanagement to populate apiName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -189,8 +188,7 @@ spec:
                     - name
                     type: object
                   apiNameSelector:
-                    description: Selector for a APIOperation in apimanagement to populate
-                      apiName.
+                    description: Selector for a API in apimanagement to populate apiName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apimanagement.azure.upbound.io_apioperationpolicies.yaml
+++ b/package/crds/apimanagement.azure.upbound.io_apioperationpolicies.yaml
@@ -78,7 +78,7 @@ spec:
                       this forces a new resource to be created.
                     type: string
                   apiManagementNameRef:
-                    description: Reference to a APIOperation in apimanagement to populate
+                    description: Reference to a Management in apimanagement to populate
                       apiManagementName.
                     properties:
                       name:
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   apiManagementNameSelector:
-                    description: Selector for a APIOperation in apimanagement to populate
+                    description: Selector for a Management in apimanagement to populate
                       apiManagementName.
                     properties:
                       matchControllerRef:
@@ -159,8 +159,7 @@ spec:
                       to be created.
                     type: string
                   apiNameRef:
-                    description: Reference to a APIOperation in apimanagement to populate
-                      apiName.
+                    description: Reference to a API in apimanagement to populate apiName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -194,8 +193,7 @@ spec:
                     - name
                     type: object
                   apiNameSelector:
-                    description: Selector for a APIOperation in apimanagement to populate
-                      apiName.
+                    description: Selector for a API in apimanagement to populate apiName.
                     properties:
                       matchControllerRef:
                         description: |-


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #1034
Adds missing resource references for azurerm_api_management_api_operation_policy

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Run E2E tests for `examples/apimanagement/cluster/v1beta1/apioperationpolicy.yaml`

[contribution process]: https://git.io/fj2m9
