### PR TITLE
Also exclude the "azure" subpackage when expanding a wildcard SUBPACKAGES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 
 SUBPACKAGES ?= monolith
 ifeq ($(strip $(SUBPACKAGES)),*)
-override SUBPACKAGES := $(filter-out monolith,$(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3))
+override SUBPACKAGES := $(filter-out monolith azure,$(shell find cmd/provider -type d -maxdepth 1 -mindepth 1 | cut -d/ -f3))
 endif
 GO_STATIC_PACKAGES ?= $(GO_PROJECT)/cmd/generator ${SUBPACKAGES:%=$(GO_PROJECT)/cmd/provider/%}
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
We do not publish `provider-azure-azure` in favor of the `provider-family-azure` so the wildcard expansion should filter it out in addition to the `monolith` package.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manually tested by running `make SUBPACKAGES="*" print-subpackages`.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
