### PR TITLE
Fix: remove `namespace` from `writeConnectionSecretToRef` examples

### DIFF
--- a/examples/apimanagement/namespaced/v1beta1/apidiagnostic.yaml
+++ b/examples/apimanagement/namespaced/v1beta1/apidiagnostic.yaml
@@ -124,7 +124,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: example-application-insights
-    namespace: upbound-system
 ---
 apiVersion: apimanagement.azure.m.upbound.io/v1beta1
 kind: Management

--- a/examples/apimanagement/namespaced/v1beta1/diagnostic.yaml
+++ b/examples/apimanagement/namespaced/v1beta1/diagnostic.yaml
@@ -96,7 +96,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: example-application-insights
-    namespace: upbound-system
 ---
 apiVersion: apimanagement.azure.m.upbound.io/v1beta1
 kind: Management

--- a/examples/apimanagement/namespaced/v1beta1/logger.yaml
+++ b/examples/apimanagement/namespaced/v1beta1/logger.yaml
@@ -45,7 +45,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: example-application-insights
-    namespace: upbound-system
 ---
 apiVersion: apimanagement.azure.m.upbound.io/v1beta1
 kind: Management

--- a/examples/apimanagement/namespaced/v1beta1/rediscache.yaml
+++ b/examples/apimanagement/namespaced/v1beta1/rediscache.yaml
@@ -36,7 +36,6 @@ metadata:
   namespace: upbound-system
 spec:
   writeConnectionSecretToRef:
-    namespace: upbound-system
     name: example-redis-cache
   forProvider:
     redisVersion: "6"

--- a/examples/containerapp/namespaced/v1beta1/environmentstorage.yaml
+++ b/examples/containerapp/namespaced/v1beta1/environmentstorage.yaml
@@ -96,7 +96,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Share

--- a/examples/datashare/namespaced/v1beta1/datasetblobstorage.yaml
+++ b/examples/datashare/namespaced/v1beta1/datasetblobstorage.yaml
@@ -44,7 +44,6 @@ spec:
       provisioner: crossplane
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/dbformysql/namespaced/v1beta1/flexibleserver.yaml
+++ b/examples/dbformysql/namespaced/v1beta1/flexibleserver.yaml
@@ -25,7 +25,6 @@ spec:
     skuName: GP_Standard_D2ds_v4
   writeConnectionSecretToRef:
     name: example-connection-flexiblemysqlserver
-    namespace: upbound-system
 ---
 apiVersion: v1
 data:

--- a/examples/dbforpostgresql/namespaced/v1beta1/server-all-in-one.yaml
+++ b/examples/dbforpostgresql/namespaced/v1beta1/server-all-in-one.yaml
@@ -161,7 +161,6 @@ spec:
     infrastructureEncryptionEnabled: false
   writeConnectionSecretToRef:
     name: example-connection-postgresqlserver
-    namespace: upbound-system
 ---
 apiVersion: azure.m.upbound.io/v1beta1
 kind: ResourceGroup

--- a/examples/hdinsight/namespaced/v1beta1/hadoopcluster.yaml
+++ b/examples/hdinsight/namespaced/v1beta1/hadoopcluster.yaml
@@ -89,7 +89,6 @@ spec:
         testing.upbound.io/example-name: rghadoopcluster
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/hdinsight/namespaced/v1beta1/hbasecluster.yaml
+++ b/examples/hdinsight/namespaced/v1beta1/hbasecluster.yaml
@@ -89,7 +89,6 @@ spec:
         testing.upbound.io/example-name: rghbasecluster
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/hdinsight/namespaced/v1beta1/interactivequerycluster.yaml
+++ b/examples/hdinsight/namespaced/v1beta1/interactivequerycluster.yaml
@@ -89,7 +89,6 @@ spec:
         testing.upbound.io/example-name: rgiqcluster
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/hdinsight/namespaced/v1beta1/kafkacluster.yaml
+++ b/examples/hdinsight/namespaced/v1beta1/kafkacluster.yaml
@@ -90,7 +90,6 @@ spec:
         testing.upbound.io/example-name: rgkafkacluster
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/hdinsight/namespaced/v1beta1/sparkcluster.yaml
+++ b/examples/hdinsight/namespaced/v1beta1/sparkcluster.yaml
@@ -89,7 +89,6 @@ spec:
         testing.upbound.io/example-name: rgsparkcluster
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/network/namespaced/v1beta1/packetcapture.yaml
+++ b/examples/network/namespaced/v1beta1/packetcapture.yaml
@@ -62,7 +62,6 @@ spec:
       provisioner: crossplane
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: network.azure.m.upbound.io/v1beta1
 kind: VirtualNetwork

--- a/examples/network/namespaced/v1beta1/watcherflowlog.yaml
+++ b/examples/network/namespaced/v1beta1/watcherflowlog.yaml
@@ -81,4 +81,3 @@ spec:
       provisioner: crossplane
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system

--- a/examples/sql/namespaced/v1beta1/mssqlmanagedinstancevulnerabilityassessment.yaml
+++ b/examples/sql/namespaced/v1beta1/mssqlmanagedinstancevulnerabilityassessment.yaml
@@ -45,4 +45,3 @@ spec:
       provisioner: crossplane
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system

--- a/examples/sql/namespaced/v1beta1/mssqlservermicrosoftsupportauditingpolicy.yaml
+++ b/examples/sql/namespaced/v1beta1/mssqlservermicrosoftsupportauditingpolicy.yaml
@@ -77,7 +77,6 @@ spec:
         testing.upbound.io/example-name: rgauditingpolicy
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: v1
 kind: Secret

--- a/examples/streamanalytics/namespaced/v1beta1/outputblob.yaml
+++ b/examples/streamanalytics/namespaced/v1beta1/outputblob.yaml
@@ -57,7 +57,6 @@ spec:
         testing.upbound.io/example-name: example
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Container

--- a/examples/streamanalytics/namespaced/v1beta1/outputtable.yaml
+++ b/examples/streamanalytics/namespaced/v1beta1/outputtable.yaml
@@ -62,7 +62,6 @@ spec:
         testing.upbound.io/example-name: groutputtable
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system
 ---
 apiVersion: storage.azure.m.upbound.io/v1beta1
 kind: Table

--- a/examples/web/namespaced/v1beta1/linuxfunctionapp.yaml
+++ b/examples/web/namespaced/v1beta1/linuxfunctionapp.yaml
@@ -80,4 +80,3 @@ spec:
         testing.upbound.io/example-name: linuxfuncapp-rg
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system

--- a/examples/web/namespaced/v1beta1/linuxfunctionappslot.yaml
+++ b/examples/web/namespaced/v1beta1/linuxfunctionappslot.yaml
@@ -99,4 +99,3 @@ spec:
         testing.upbound.io/example-name: linuxfuncnappslot-rg
   writeConnectionSecretToRef:
     name: example-storage-account
-    namespace: upbound-system


### PR DESCRIPTION

<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Remove `spec.writeConnectionSecretToRef.namespace` from namespace-scoped examples as it no longer exists in CRDs

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested manually on Kind - installed required CRDs without controller, applied before changes which leads to validation error, removed namespace and applied

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
