### PR TITLE
[Fix]: Unable to create FrontdoorFirewallPolicy

### DIFF
--- a/config/cluster/cdn/config.go
+++ b/config/cluster/cdn/config.go
@@ -38,5 +38,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_cdn_frontdoor_firewall_policy", func(r *config.Resource) {
 		r.ShortGroup = "cdn"
 		r.Kind = "FrontdoorFirewallPolicy"
+		r.UseAsync = true
 	})
 }

--- a/config/namespaced/cdn/config.go
+++ b/config/namespaced/cdn/config.go
@@ -38,5 +38,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_cdn_frontdoor_firewall_policy", func(r *config.Resource) {
 		r.ShortGroup = "cdn"
 		r.Kind = "FrontdoorFirewallPolicy"
+		r.UseAsync = true
 	})
 }

--- a/examples/cdn/cluster/testhooks/delete-frontdoorfirewallpolicy.sh
+++ b/examples/cdn/cluster/testhooks/delete-frontdoorfirewallpolicy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Note(jonasz-lasut): We are getting observe failed: failed to observe the resource: [{0 retrieving Front Door Web Application Firewall Policy (Subscription: "0a7d218a-1c62-4113-9660-9fbf629fe279"
+# Resource Group Name: "frontdoorfirewallpolicy" Front Door Web Application Firewall Policy Name: "frontdoorfirewallpolicy"):
+# webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient#PoliciesGet: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'frontdoorfirewallpolicy' could not be found."  []}].
+# This is a workaround for this problem to make automated tests to work.
+${KUBECTL} delete frontdoorfirewallpolicy.cdn.azure.upbound.io -l testing.upbound.io/example-name=frontdoorfirewallpolicy

--- a/examples/cdn/cluster/v1beta1/frontdoorfirewallpolicy.yaml
+++ b/examples/cdn/cluster/v1beta1/frontdoorfirewallpolicy.yaml
@@ -115,6 +115,7 @@ kind: ResourceGroup
 metadata:
   annotations:
     meta.upbound.io/example-id: cdn/v1beta1/frontdoorfirewallpolicy
+    uptest.upbound.io/pre-delete-hook: ../testhooks/delete-frontdoorfirewallpolicy.sh
   labels:
     testing.upbound.io/example-name: frontdoorfirewallpolicy
   name: frontdoorfirewallpolicy

--- a/examples/cdn/namespaced/testhooks/delete-frontdoorfirewallpolicy.sh
+++ b/examples/cdn/namespaced/testhooks/delete-frontdoorfirewallpolicy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -aeuo pipefail
+
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Note(jonasz-lasut): We are getting observe failed: failed to observe the resource: [{0 retrieving Front Door Web Application Firewall Policy (Subscription: "0a7d218a-1c62-4113-9660-9fbf629fe279"
+# Resource Group Name: "frontdoorfirewallpolicy" Front Door Web Application Firewall Policy Name: "frontdoorfirewallpolicy"):
+# webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient#PoliciesGet: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'frontdoorfirewallpolicy' could not be found."  []}].
+# This is a workaround for this problem to make automated tests to work.
+${KUBECTL} delete frontdoorfirewallpolicy.cdn.azure.m.upbound.io -l testing.upbound.io/example-name=frontdoorfirewallpolicy

--- a/examples/cdn/namespaced/v1beta1/frontdoorfirewallpolicy.yaml
+++ b/examples/cdn/namespaced/v1beta1/frontdoorfirewallpolicy.yaml
@@ -113,6 +113,7 @@ kind: ResourceGroup
 metadata:
   annotations:
     meta.upbound.io/example-id: cdn/v1beta1/frontdoorfirewallpolicy
+    uptest.upbound.io/pre-delete-hook: ../testhooks/delete-frontdoorfirewallpolicy.sh
   labels:
     testing.upbound.io/example-name: frontdoorfirewallpolicy
   name: frontdoorfirewallpolicy


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
FrontdoorFirewallPolicy needs to be created asynchronously otherwise it returns 404 during creation even though the resource creation call is short.
```yaml
status:
  atProvider: {}
  conditions:
    - lastTransitionTime: '2025-09-27T15:15:29Z'
      message: >-
        observe failed: failed to observe the resource: [{0 retrieving Front
        Door Web Application Firewall Policy (Subscription:
        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx9965"

        Resource Group Name: "rg-adhoc-core-np-neu"

        Front Door Web Application Firewall Policy Name:
        "fdadhoccorenpneutest2"):
        webapplicationfirewallpolicies.WebApplicationFirewallPoliciesClient#PoliciesGet:
        Failure responding to request: StatusCode=404 -- Original Error:
        autorest/azure: Service returned an error. Status=404
        Code="ResourceNotFound" Message="The Resource
        'Microsoft.Network/frontdoorWebApplicationFirewallPolicies/fdadhoccorenpneutest2'
        under resource group 'rg-adhoc-core-np-neu' was not found. For more
        details please go to https://aka.ms/ARMResourceNotFoundFix"  []}]
      observedGeneration: 2
      reason: ReconcileError
      status: 'False'
      type: Synced
```

Fixes #1067 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Run E2E tests
`UPTEST_EXAMPLE_LIST="examples/cdn/cluster/v1beta1/frontdoorfirewallpolicy.yaml" make e2e`

[contribution process]: https://git.io/fj2m9
