### PR TITLE
Fix: ManagementGroupSubscriptionAssociation observe fails

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2028,7 +2028,7 @@ func storageDataLakeGen2Filesystem() config.ExternalName {
 }
 
 // custom function for azurerm_management_group_subscription_association
-// /managementGroup/MyManagementGroup/subscription/12345678-1234-1234-1234-123456789012
+// /providers/Microsoft.Management/managementGroups/MyManagementGroup/subscriptions/12345678-1234-1234-1234-123456789012
 func managementGroupSubscriptionAssociation() config.ExternalName {
 	e := config.IdentifierFromProvider
 	e.GetExternalNameFn = func(tfstate map[string]interface{}) (string, error) {
@@ -2046,7 +2046,7 @@ func managementGroupSubscriptionAssociation() config.ExternalName {
 		w := strings.Split(externalName, "/")
 		managementGroupName := w[0]
 		subscriptionId := w[1]
-		return fmt.Sprintf("/managementGroup/%s/subscription/%s", managementGroupName, subscriptionId), nil
+		return fmt.Sprintf("/providers/Microsoft.Management/managementGroups/%s/subscriptions/%s", managementGroupName, subscriptionId), nil
 	}
 	return e
 }

--- a/examples/management/namespaced/testhooks/delete-management-group-association.sh
+++ b/examples/management/namespaced/testhooks/delete-management-group-association.sh
@@ -9,4 +9,4 @@ set -aeuo pipefail
 # If deletion executed in parallel the ManagementGroupSubscriptionAssociation
 # will stuck with
 #  Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client '$uuid' with object id '$uuid' does not have authorization to perform action 'Microsoft.Management/managementGroups/read' over scope '/providers/Microsoft.Management/managementGroups/example-sub' or the scope is invalid. If access was recently granted, please refresh your credentials.":
-${KUBECTL} delete managementgroupsubscriptionassociations.management.azure.upbound.io --all
+${KUBECTL} delete managementgroupsubscriptionassociations.management.azure.m.upbound.io -n upbound-system --all


### PR DESCRIPTION
### Description of your changes
Fixes #1112
The import ID structure has changed when updating the Terraform provider in v2.0.0. The following PR fixes that problem.
Fixed the incorrect api group in testhook for managementgroupsubscriptionassociation as well

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Run e2e tests on pipeline for `examples/management/cluster/v1beta1/managementgroupsubscriptionassociation.yaml`

[contribution process]: https://git.io/fj2m9
