### PR TITLE
Implement custom diff for MonitorScheduledQueryRulesAlertV2

### DIFF
--- a/config/cluster/insights/config.go
+++ b/config/cluster/insights/config.go
@@ -7,15 +7,15 @@ package insights
 import (
 	"fmt"
 
+	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
-	"github.com/upbound/provider-azure/v2/apis/cluster/rconfig"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/upbound/provider-azure/v2/apis/cluster/rconfig"
 )
 
 // Configure configures insights group
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("azurerm_monitor_metric_alert", func(r *config.Resource) {
 		r.References["scopes"] = config.Reference{
 			TerraformName: "azurerm_storage_account",
@@ -53,7 +53,7 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_application_insights",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
-		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if state == nil || state.Empty() || diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
 				return diff, nil
 			}

--- a/config/namespaced/insights/config.go
+++ b/config/namespaced/insights/config.go
@@ -7,15 +7,15 @@ package insights
 import (
 	"fmt"
 
+	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
-	"github.com/upbound/provider-azure/v2/apis/namespaced/rconfig"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/upbound/provider-azure/v2/apis/namespaced/rconfig"
 )
 
 // Configure configures insights group
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("azurerm_monitor_metric_alert", func(r *config.Resource) {
 		r.References["scopes"] = config.Reference{
 			TerraformName: "azurerm_storage_account",
@@ -53,7 +53,7 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_application_insights",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
-		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, state *terraform.InstanceState, config *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if state == nil || state.Empty() || diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
 				return diff, nil
 			}


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #1123 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manual check, applied:
```
apiVersion: azure.upbound.io/v1beta1
kind: ResourceGroup
metadata:
  name: rg-dev-ijospov
spec:
  forProvider:
    location: Central US
---
apiVersion: insights.azure.upbound.io/v1beta1
kind: ApplicationInsights
metadata:
  name: appi-dev-ijospov
spec:
  forProvider:
    location: Central US
    applicationType: web
    resourceGroupNameRef:
      name: rg-dev-ijospov
---
apiVersion: insights.azure.upbound.io/v1beta1
kind: MonitorScheduledQueryRulesAlertV2
metadata:
  name: testqueryalert1-bad
spec:
  forProvider:
    autoMitigationEnabled: true
    criteria:
      - operator: GreaterThanOrEqual
        query: >
          traces
          | where cloud_RoleName == "test-app"
        threshold: 2
        timeAggregationMethod: Count
    evaluationFrequency: PT10M
    location: Central US
    resourceGroupNameRef:
      name: rg-dev-ijospov
    scopes:
      - /subscriptions/{subId}/resourceGroups/rg-dev-ijospov/providers/Microsoft.Insights/components/appi-dev-ijospov
    severity: 1
    windowDuration: PT60M
```
logs:
```
2026-01-20T13:39:29+01:00       DEBUG   provider-azure  External resource is up to date {"controller": "managed/insights.azure.upbound.io/v1beta1, kind=monitorscheduledqueryrulesalertv2", "request": {"name":"testqueryalert1-bad"}, "uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "version": "416688", "external-name": "testqueryalert1-bad", "requeue-after": "2026-01-20T13:49:30+01:00"}
2026-01-20T13:39:29+01:00       DEBUG   provider-azure  Calling the inner handler for Update event.     {"gvk": "insights.azure.upbound.io/v1beta1, Kind=MonitorScheduledQueryRulesAlertV2", "name": "testqueryalert1-bad", "namespace": "", "queueLength": 0}
2026-01-20T13:39:29+01:00       DEBUG   provider-azure  Reconciling     {"controller": "managed/insights.azure.upbound.io/v1beta1, kind=monitorscheduledqueryrulesalertv2", "request": {"name":"testqueryalert1-bad"}}
2026-01-20T13:39:29+01:00       DEBUG   provider-azure  Connecting to the service provider      {"uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "name": "testqueryalert1-bad", "namespace": "", "gvk": "insights.azure.upbound.io/v1beta1, Kind=MonitorScheduledQueryRulesAlertV2"}
2026-01-20T13:39:29+01:00       DEBUG   provider-azure  Observing the external resource {"uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "name": "testqueryalert1-bad", "namespace": "", "gvk": "insights.azure.upbound.io/v1beta1, Kind=MonitorScheduledQueryRulesAlertV2"}
2026-01-20T13:39:30+01:00       DEBUG   provider-azure  External resource is up to date {"controller": "managed/insights.azure.upbound.io/v1beta1, kind=monitorscheduledqueryrulesalertv2", "request": {"name":"testqueryalert1-bad"}, "uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "version": "416689", "external-name": "testqueryalert1-bad", "requeue-after": "2026-01-20T13:49:16+01:00"}
2026-01-20T13:39:31+01:00       DEBUG   provider-azure  Reconciling     {"controller": "managed/insights.azure.upbound.io/v1beta1, kind=monitorscheduledqueryrulesalertv2", "request": {"name":"testqueryalert1-bad"}}
2026-01-20T13:39:31+01:00       DEBUG   provider-azure  Connecting to the service provider      {"uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "name": "testqueryalert1-bad", "namespace": "", "gvk": "insights.azure.upbound.io/v1beta1, Kind=MonitorScheduledQueryRulesAlertV2"}
2026-01-20T13:39:31+01:00       DEBUG   provider-azure  Observing the external resource {"uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "name": "testqueryalert1-bad", "namespace": "", "gvk": "insights.azure.upbound.io/v1beta1, Kind=MonitorScheduledQueryRulesAlertV2"}
2026-01-20T13:39:31+01:00       DEBUG   provider-azure  External resource is up to date {"controller": "managed/insights.azure.upbound.io/v1beta1, kind=monitorscheduledqueryrulesalertv2", "request": {"name":"testqueryalert1-bad"}, "uid": "8b1abdd5-8b46-4c4a-a48b-72f352a8e6b5", "version": "416690", "external-name": "testqueryalert1-bad", "requeue-after": "2026-01-20T13:49:29+01:00"}
2026-01-20T13:45:27+01:00       DEBUG   provider-azure  Reconciling     {"controller": "managed/azure.upbound.io/v1beta1, kind=resourcegroup", "request": {"name":"rg-dev-ijospov"}}
2026-01-20T13:45:27+01:00       DEBUG   provider-azure  Connecting to the service provider      {"uid": "bd41dbd0-0459-4c2f-9746-e7afaaec0ab9", "name": "rg-dev-ijospov", "namespace": "", "gvk": "azure.upbound.io/v1beta1, Kind=ResourceGroup"}
2026-01-20T13:45:28+01:00       DEBUG   provider-azure  Observing the external resource {"uid": "bd41dbd0-0459-4c2f-9746-e7afaaec0ab9", "name": "rg-dev-ijospov", "namespace": "", "gvk": "azure.upbound.io/v1beta1, Kind=ResourceGroup"}
2026-01-20T13:45:29+01:00       DEBUG   provider-azure  External resource is up to date {"controller": "managed/azure.upbound.io/v1beta1, kind=resourcegroup", "request": {"name":"rg-dev-ijospov"}, "uid": "bd41dbd0-0459-4c2f-9746-e7afaaec0ab9", "version": "416079", "external-name": "rg-dev-ijospov", "requeue-after": "2026-01-20T13:55:15+01:00"}
```

[contribution process]: https://git.io/fj2m9
