### PR TITLE
feat: fall back to env vars for clientID/tenantID with OIDCTokenFile

### DIFF
--- a/apis/namespaced/v1beta1/types.go
+++ b/apis/namespaced/v1beta1/types.go
@@ -16,10 +16,14 @@ type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`
 
-	// ClientID is the user-assigned managed identity's ID
-	// when Credentials.Source is `InjectedIdentity`. If unset and
-	// Credentials.Source is `InjectedIdentity`, then a system-assigned
-	// managed identity is used.
+	// ClientID is the client ID of the managed identity or service principal.
+	// When Credentials.Source is `InjectedIdentity` (MSI), this selects a
+	// user-assigned identity; if unset, the system-assigned identity is used.
+	// When Credentials.Source is `OIDCTokenFile`, this field is optional: if
+	// unset, the value is read from the AZURE_CLIENT_ID environment variable,
+	// which the Azure Workload Identity webhook injects per pod from the
+	// ServiceAccount annotation. This allows a single ClusterProviderConfig to
+	// serve multiple providers, each using its own managed identity.
 	// +optional
 	ClientID *string `json:"clientID,omitempty"`
 
@@ -32,6 +36,9 @@ type ProviderConfigSpec struct {
 	// TenantID is the Azure AD tenant ID to be used.
 	// If unset, tenant ID from Credentials will be used.
 	// Required if Credentials.Source is InjectedIdentity.
+	// When Credentials.Source is `OIDCTokenFile`, this field is optional: if
+	// unset, the value is read from the AZURE_TENANT_ID environment variable,
+	// which the Azure Workload Identity webhook injects per pod.
 	// +kubebuilder:validation:Optional
 	TenantID *string `json:"tenantID,omitempty"`
 

--- a/internal/clients/azure.go
+++ b/internal/clients/azure.go
@@ -7,6 +7,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"sync/atomic"
 
@@ -32,8 +33,11 @@ const (
 	errExtractCredentials   = "cannot extract credentials"
 	errUnmarshalCredentials = "cannot unmarshal Azure credentials as JSON"
 	errSubscriptionIDNotSet = "subscription ID must be set in ProviderConfig when credential source is InjectedIdentity, OIDCTokenFile or Upbound"
-	errTenantIDNotSet       = "tenant ID must be set in ProviderConfig when credential source is InjectedIdentity, OIDCTokenFile or Upbound"
-	errClientIDNotSet       = "client ID must be set in ProviderConfig when credential source is OIDCTokenFile or Upbound"
+	errTenantIDNotSet       = "tenant ID must be set in ProviderConfig or AZURE_TENANT_ID env var when credential source is InjectedIdentity, OIDCTokenFile or Upbound"
+	errClientIDNotSet       = "client ID must be set in ProviderConfig or AZURE_CLIENT_ID env var when credential source is OIDCTokenFile or Upbound"
+	// Environment variable names for Azure Workload Identity webhook-injected values
+	envAzureClientID = "AZURE_CLIENT_ID"
+	envAzureTenantID = "AZURE_TENANT_ID"
 	// Azure service principal credentials file JSON keys
 	keyAzureSubscriptionID = "subscriptionId"
 	keyAzureClientID       = "clientId"
@@ -200,24 +204,42 @@ func msiAuth(pcSpec *namespacedv1beta1.ProviderConfigSpec, ps *terraform.Setup) 
 	return nil
 }
 
+// specOrEnv returns the spec value if non-nil and non-empty, otherwise the
+// value of the named environment variable.
+func specOrEnv(specVal *string, envVar string) string {
+	if specVal != nil && len(*specVal) > 0 {
+		return *specVal
+	}
+	return os.Getenv(envVar)
+}
+
 func oidcAuth(pcSpec *namespacedv1beta1.ProviderConfigSpec, ps *terraform.Setup) error {
 	if pcSpec.SubscriptionID == nil || len(*pcSpec.SubscriptionID) == 0 {
 		return errors.New(errSubscriptionIDNotSet)
 	}
-	if pcSpec.TenantID == nil || len(*pcSpec.TenantID) == 0 {
+
+	// tenantID and clientID are optional in the spec for OIDCTokenFile: when the
+	// Azure Workload Identity webhook is enabled on the provider pod, it injects
+	// AZURE_TENANT_ID and AZURE_CLIENT_ID per pod, enabling per-provider managed
+	// identities without a cluster-wide ClusterProviderConfig per identity.
+	tenantID := specOrEnv(pcSpec.TenantID, envAzureTenantID)
+	if tenantID == "" {
 		return errors.New(errTenantIDNotSet)
 	}
-	if pcSpec.ClientID == nil || len(*pcSpec.ClientID) == 0 {
+
+	clientID := specOrEnv(pcSpec.ClientID, envAzureClientID)
+	if clientID == "" {
 		return errors.New(errClientIDNotSet)
 	}
+
 	// OIDC Token File Path defaults to a projected-volume path mounted in the pod running in the AKS cluster, when workload identity is enabled on the pod.
 	ps.Configuration[keyOidcTokenFilePath] = defaultOidcTokenFilePath
 	if pcSpec.OidcTokenFilePath != nil {
 		ps.Configuration[keyOidcTokenFilePath] = *pcSpec.OidcTokenFilePath
 	}
 	ps.Configuration[keySubscriptionID] = *pcSpec.SubscriptionID
-	ps.Configuration[keyTenantID] = *pcSpec.TenantID
-	ps.Configuration[keyClientID] = *pcSpec.ClientID
+	ps.Configuration[keyTenantID] = tenantID
+	ps.Configuration[keyClientID] = clientID
 	ps.Configuration[keyUseOIDC] = "true"
 	if pcSpec.Environment != nil {
 		ps.Configuration[keyEnvironment] = *pcSpec.Environment

--- a/internal/clients/azure_test.go
+++ b/internal/clients/azure_test.go
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
+	"github.com/google/go-cmp/cmp"
+
+	namespacedv1beta1 "github.com/upbound/provider-azure/v2/apis/namespaced/v1beta1"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestOIDCAuth(t *testing.T) {
+	subscriptionID := "sub-123"
+
+	cases := map[string]struct {
+		pcSpec  *namespacedv1beta1.ProviderConfigSpec
+		envVars map[string]string
+		want    terraform.ProviderConfiguration
+		wantErr string
+	}{
+		"AllFieldsInSpec": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+				TenantID:       ptr("tenant-spec"),
+				ClientID:       ptr("client-spec"),
+			},
+			want: terraform.ProviderConfiguration{
+				keyOidcTokenFilePath: defaultOidcTokenFilePath,
+				keySubscriptionID:    subscriptionID,
+				keyTenantID:          "tenant-spec",
+				keyClientID:          "client-spec",
+				keyUseOIDC:           "true",
+			},
+		},
+		"ClientIDAndTenantIDFromEnvVars": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+			},
+			envVars: map[string]string{
+				envAzureClientID: "client-env",
+				envAzureTenantID: "tenant-env",
+			},
+			want: terraform.ProviderConfiguration{
+				keyOidcTokenFilePath: defaultOidcTokenFilePath,
+				keySubscriptionID:    subscriptionID,
+				keyTenantID:          "tenant-env",
+				keyClientID:          "client-env",
+				keyUseOIDC:           "true",
+			},
+		},
+		"SpecTakesPrecedenceOverEnvVars": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+				TenantID:       ptr("tenant-spec"),
+				ClientID:       ptr("client-spec"),
+			},
+			envVars: map[string]string{
+				envAzureClientID: "client-env",
+				envAzureTenantID: "tenant-env",
+			},
+			want: terraform.ProviderConfiguration{
+				keyOidcTokenFilePath: defaultOidcTokenFilePath,
+				keySubscriptionID:    subscriptionID,
+				keyTenantID:          "tenant-spec",
+				keyClientID:          "client-spec",
+				keyUseOIDC:           "true",
+			},
+		},
+		"CustomTokenFilePath": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID:    ptr(subscriptionID),
+				TenantID:          ptr("tenant-spec"),
+				ClientID:          ptr("client-spec"),
+				OidcTokenFilePath: ptr("/custom/token/path"),
+			},
+			want: terraform.ProviderConfiguration{
+				keyOidcTokenFilePath: "/custom/token/path",
+				keySubscriptionID:    subscriptionID,
+				keyTenantID:          "tenant-spec",
+				keyClientID:          "client-spec",
+				keyUseOIDC:           "true",
+			},
+		},
+		"MissingSubscriptionID": {
+			pcSpec:  &namespacedv1beta1.ProviderConfigSpec{},
+			wantErr: errSubscriptionIDNotSet,
+		},
+		"MissingTenantIDNoEnvVar": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+				ClientID:       ptr("client-spec"),
+			},
+			wantErr: errTenantIDNotSet,
+		},
+		"MissingClientIDNoEnvVar": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+				TenantID:       ptr("tenant-spec"),
+			},
+			wantErr: errClientIDNotSet,
+		},
+		"TenantIDFromEnvClientIDMissing": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+			},
+			envVars: map[string]string{
+				envAzureTenantID: "tenant-env",
+			},
+			wantErr: errClientIDNotSet,
+		},
+		"ClientIDFromEnvTenantIDMissing": {
+			pcSpec: &namespacedv1beta1.ProviderConfigSpec{
+				SubscriptionID: ptr(subscriptionID),
+			},
+			envVars: map[string]string{
+				envAzureClientID: "client-env",
+			},
+			wantErr: errTenantIDNotSet,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Set env vars for this test case.
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			ps := &terraform.Setup{
+				Configuration: terraform.ProviderConfiguration{},
+			}
+
+			err := oidcAuth(tc.pcSpec, ps)
+
+			if tc.wantErr != "" {
+				if diff := cmp.Diff(tc.wantErr, err.Error(), test.EquateConditions()); diff != "" {
+					t.Errorf("oidcAuth() error mismatch (-want +got):\n%s", diff)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("oidcAuth() unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.want, ps.Configuration); diff != "" {
+				t.Errorf("oidcAuth() configuration mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/package/crds/azure.m.upbound.io_clusterproviderconfigs.yaml
+++ b/package/crds/azure.m.upbound.io_clusterproviderconfigs.yaml
@@ -53,10 +53,14 @@ spec:
             properties:
               clientID:
                 description: |-
-                  ClientID is the user-assigned managed identity's ID
-                  when Credentials.Source is `InjectedIdentity`. If unset and
-                  Credentials.Source is `InjectedIdentity`, then a system-assigned
-                  managed identity is used.
+                  ClientID is the client ID of the managed identity or service principal.
+                  When Credentials.Source is `InjectedIdentity` (MSI), this selects a
+                  user-assigned identity; if unset, the system-assigned identity is used.
+                  When Credentials.Source is `OIDCTokenFile`, this field is optional: if
+                  unset, the value is read from the AZURE_CLIENT_ID environment variable,
+                  which the Azure Workload Identity webhook injects per pod from the
+                  ServiceAccount annotation. This allows a single ClusterProviderConfig to
+                  serve multiple providers, each using its own managed identity.
                 type: string
               credentials:
                 description: Credentials required to authenticate to this provider.
@@ -148,6 +152,9 @@ spec:
                   TenantID is the Azure AD tenant ID to be used.
                   If unset, tenant ID from Credentials will be used.
                   Required if Credentials.Source is InjectedIdentity.
+                  When Credentials.Source is `OIDCTokenFile`, this field is optional: if
+                  unset, the value is read from the AZURE_TENANT_ID environment variable,
+                  which the Azure Workload Identity webhook injects per pod.
                 type: string
             required:
             - credentials

--- a/package/crds/azure.m.upbound.io_providerconfigs.yaml
+++ b/package/crds/azure.m.upbound.io_providerconfigs.yaml
@@ -53,10 +53,14 @@ spec:
             properties:
               clientID:
                 description: |-
-                  ClientID is the user-assigned managed identity's ID
-                  when Credentials.Source is `InjectedIdentity`. If unset and
-                  Credentials.Source is `InjectedIdentity`, then a system-assigned
-                  managed identity is used.
+                  ClientID is the client ID of the managed identity or service principal.
+                  When Credentials.Source is `InjectedIdentity` (MSI), this selects a
+                  user-assigned identity; if unset, the system-assigned identity is used.
+                  When Credentials.Source is `OIDCTokenFile`, this field is optional: if
+                  unset, the value is read from the AZURE_CLIENT_ID environment variable,
+                  which the Azure Workload Identity webhook injects per pod from the
+                  ServiceAccount annotation. This allows a single ClusterProviderConfig to
+                  serve multiple providers, each using its own managed identity.
                 type: string
               credentials:
                 description: Credentials required to authenticate to this provider.
@@ -148,6 +152,9 @@ spec:
                   TenantID is the Azure AD tenant ID to be used.
                   If unset, tenant ID from Credentials will be used.
                   Required if Credentials.Source is InjectedIdentity.
+                  When Credentials.Source is `OIDCTokenFile`, this field is optional: if
+                  unset, the value is read from the AZURE_TENANT_ID environment variable,
+                  which the Azure Workload Identity webhook injects per pod.
                 type: string
             required:
             - credentials


### PR DESCRIPTION
## Summary

Fixes #1166.

When `Credentials.Source` is `OIDCTokenFile`, `clientID` and `tenantID` are now optional in the `ProviderConfig` spec. `oidcAuth()` reads `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` from the environment when the spec fields are absent, with spec values taking precedence when set.

This enables AKS deployments using the Azure Workload Identity webhook: the webhook injects `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` per pod via `ServiceAccount` annotations, so each provider deployment can use a distinct managed identity without requiring a separate `ClusterProviderConfig` per identity.

`subscriptionID` remains required in the spec.

## Changes

- `internal/clients/azure.go`: updated `oidcAuth()` to read `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` env vars as fallback; updated error message constants to reflect the new behavior
- `apis/namespaced/v1beta1/types.go`: updated doc comments on `ClientID` and `TenantID` fields to document the env var fallback for `OIDCTokenFile`
- `internal/clients/azure_test.go`: new unit tests covering all fallback scenarios

## Test plan

- `go test ./internal/clients/...` passes (8 subtests)
- Manually: apply a `ClusterProviderConfig` with no `clientID`/`tenantID` against an AKS cluster with Workload Identity enabled; confirm the webhook-injected env vars are picked up

cc @jonasz-lasut