### PR TITLE
Add elastic pool reference support to MSSQLDatabase

### DIFF
--- a/apis/cluster/sql/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/sql/v1beta1/zz_generated.deepcopy.go
@@ -1039,6 +1039,16 @@ func (in *MSSQLDatabaseInitParameters) DeepCopyInto(out *MSSQLDatabaseInitParame
 		*out = new(string)
 		**out = **in
 	}
+	if in.ElasticPoolIDRef != nil {
+		in, out := &in.ElasticPoolIDRef, &out.ElasticPoolIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ElasticPoolIDSelector != nil {
+		in, out := &in.ElasticPoolIDSelector, &out.ElasticPoolIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnclaveType != nil {
 		in, out := &in.EnclaveType, &out.EnclaveType
 		*out = new(string)
@@ -1492,6 +1502,16 @@ func (in *MSSQLDatabaseParameters) DeepCopyInto(out *MSSQLDatabaseParameters) {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID
 		*out = new(string)
 		**out = **in
+	}
+	if in.ElasticPoolIDRef != nil {
+		in, out := &in.ElasticPoolIDRef, &out.ElasticPoolIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ElasticPoolIDSelector != nil {
+		in, out := &in.ElasticPoolIDSelector, &out.ElasticPoolIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EnclaveType != nil {
 		in, out := &in.EnclaveType, &out.EnclaveType

--- a/apis/cluster/sql/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/sql/v1beta1/zz_generated.resolvers.go
@@ -26,6 +26,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	var rsp reference.ResolutionResponse
 	var mrsp reference.MultiResolutionResponse
 	var err error
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ElasticPoolID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.ElasticPoolIDRef,
+			Selector:     mg.Spec.ForProvider.ElasticPoolIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.ElasticPoolID")
+	}
+	mg.Spec.ForProvider.ElasticPoolID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ElasticPoolIDRef = rsp.ResolvedReference
 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Identity); i3++ {
 		{
@@ -88,6 +108,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	}
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ElasticPoolID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.ElasticPoolIDRef,
+			Selector:     mg.Spec.InitProvider.ElasticPoolIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.ElasticPoolID")
+	}
+	mg.Spec.InitProvider.ElasticPoolID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.ElasticPoolIDRef = rsp.ResolvedReference
 
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.Identity); i3++ {
 		{

--- a/apis/cluster/sql/v1beta1/zz_mssqldatabase_types.go
+++ b/apis/cluster/sql/v1beta1/zz_mssqldatabase_types.go
@@ -206,7 +206,17 @@ type MSSQLDatabaseInitParameters struct {
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
 
 	// Specifies the ID of the elastic pool containing this database.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta1.MSSQLElasticPool
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	ElasticPoolID *string `json:"elasticPoolId,omitempty" tf:"elastic_pool_id,omitempty"`
+
+	// Reference to a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDRef *v1.Reference `json:"elasticPoolIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDSelector *v1.Selector `json:"elasticPoolIdSelector,omitempty" tf:"-"`
 
 	// Specifies the type of enclave to be used by the database. Possible value VBS.
 	EnclaveType *string `json:"enclaveType,omitempty" tf:"enclave_type,omitempty"`
@@ -432,8 +442,18 @@ type MSSQLDatabaseParameters struct {
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
 
 	// Specifies the ID of the elastic pool containing this database.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta1.MSSQLElasticPool
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ElasticPoolID *string `json:"elasticPoolId,omitempty" tf:"elastic_pool_id,omitempty"`
+
+	// Reference to a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDRef *v1.Reference `json:"elasticPoolIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDSelector *v1.Selector `json:"elasticPoolIdSelector,omitempty" tf:"-"`
 
 	// Specifies the type of enclave to be used by the database. Possible value VBS.
 	// +kubebuilder:validation:Optional

--- a/apis/cluster/sql/v1beta2/zz_generated.deepcopy.go
+++ b/apis/cluster/sql/v1beta2/zz_generated.deepcopy.go
@@ -694,6 +694,16 @@ func (in *MSSQLDatabaseInitParameters) DeepCopyInto(out *MSSQLDatabaseInitParame
 		*out = new(string)
 		**out = **in
 	}
+	if in.ElasticPoolIDRef != nil {
+		in, out := &in.ElasticPoolIDRef, &out.ElasticPoolIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ElasticPoolIDSelector != nil {
+		in, out := &in.ElasticPoolIDSelector, &out.ElasticPoolIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnclaveType != nil {
 		in, out := &in.EnclaveType, &out.EnclaveType
 		*out = new(string)
@@ -1127,6 +1137,16 @@ func (in *MSSQLDatabaseParameters) DeepCopyInto(out *MSSQLDatabaseParameters) {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID
 		*out = new(string)
 		**out = **in
+	}
+	if in.ElasticPoolIDRef != nil {
+		in, out := &in.ElasticPoolIDRef, &out.ElasticPoolIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ElasticPoolIDSelector != nil {
+		in, out := &in.ElasticPoolIDSelector, &out.ElasticPoolIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EnclaveType != nil {
 		in, out := &in.EnclaveType, &out.EnclaveType

--- a/apis/cluster/sql/v1beta2/zz_generated.resolvers.go
+++ b/apis/cluster/sql/v1beta2/zz_generated.resolvers.go
@@ -26,6 +26,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	var rsp reference.ResolutionResponse
 	var mrsp reference.MultiResolutionResponse
 	var err error
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta2", "MSSQLElasticPool", "MSSQLElasticPoolList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ElasticPoolID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.ElasticPoolIDRef,
+			Selector:     mg.Spec.ForProvider.ElasticPoolIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.ElasticPoolID")
+	}
+	mg.Spec.ForProvider.ElasticPoolID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ElasticPoolIDRef = rsp.ResolvedReference
 
 	if mg.Spec.ForProvider.Identity != nil {
 		{
@@ -88,6 +108,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	}
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta2", "MSSQLElasticPool", "MSSQLElasticPoolList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ElasticPoolID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.ElasticPoolIDRef,
+			Selector:     mg.Spec.InitProvider.ElasticPoolIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.ElasticPoolID")
+	}
+	mg.Spec.InitProvider.ElasticPoolID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.ElasticPoolIDRef = rsp.ResolvedReference
 
 	if mg.Spec.InitProvider.Identity != nil {
 		{

--- a/apis/cluster/sql/v1beta2/zz_mssqldatabase_types.go
+++ b/apis/cluster/sql/v1beta2/zz_mssqldatabase_types.go
@@ -212,7 +212,17 @@ type MSSQLDatabaseInitParameters struct {
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
 
 	// Specifies the ID of the elastic pool containing this database.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta2.MSSQLElasticPool
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	ElasticPoolID *string `json:"elasticPoolId,omitempty" tf:"elastic_pool_id,omitempty"`
+
+	// Reference to a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDRef *v1.Reference `json:"elasticPoolIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDSelector *v1.Selector `json:"elasticPoolIdSelector,omitempty" tf:"-"`
 
 	// Specifies the type of enclave to be used by the elastic pool. When enclave_type is not specified (e.g., the default) enclaves are not enabled on the database. Once enabled (e.g., by specifying Default or VBS) removing the enclave_type field from the configuration file will force the creation of a new resource. Possible values are Default or VBS.
 	EnclaveType *string `json:"enclaveType,omitempty" tf:"enclave_type,omitempty"`
@@ -438,8 +448,18 @@ type MSSQLDatabaseParameters struct {
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
 
 	// Specifies the ID of the elastic pool containing this database.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta2.MSSQLElasticPool
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ElasticPoolID *string `json:"elasticPoolId,omitempty" tf:"elastic_pool_id,omitempty"`
+
+	// Reference to a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDRef *v1.Reference `json:"elasticPoolIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDSelector *v1.Selector `json:"elasticPoolIdSelector,omitempty" tf:"-"`
 
 	// Specifies the type of enclave to be used by the elastic pool. When enclave_type is not specified (e.g., the default) enclaves are not enabled on the database. Once enabled (e.g., by specifying Default or VBS) removing the enclave_type field from the configuration file will force the creation of a new resource. Possible values are Default or VBS.
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/sql/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/sql/v1beta1/zz_generated.deepcopy.go
@@ -1041,6 +1041,16 @@ func (in *MSSQLDatabaseInitParameters) DeepCopyInto(out *MSSQLDatabaseInitParame
 		*out = new(string)
 		**out = **in
 	}
+	if in.ElasticPoolIDRef != nil {
+		in, out := &in.ElasticPoolIDRef, &out.ElasticPoolIDRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ElasticPoolIDSelector != nil {
+		in, out := &in.ElasticPoolIDSelector, &out.ElasticPoolIDSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnclaveType != nil {
 		in, out := &in.EnclaveType, &out.EnclaveType
 		*out = new(string)
@@ -1474,6 +1484,16 @@ func (in *MSSQLDatabaseParameters) DeepCopyInto(out *MSSQLDatabaseParameters) {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID
 		*out = new(string)
 		**out = **in
+	}
+	if in.ElasticPoolIDRef != nil {
+		in, out := &in.ElasticPoolIDRef, &out.ElasticPoolIDRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ElasticPoolIDSelector != nil {
+		in, out := &in.ElasticPoolIDSelector, &out.ElasticPoolIDSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EnclaveType != nil {
 		in, out := &in.EnclaveType, &out.EnclaveType

--- a/apis/namespaced/sql/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/sql/v1beta1/zz_generated.resolvers.go
@@ -26,6 +26,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	var rsp reference.NamespacedResolutionResponse
 	var mrsp reference.MultiNamespacedResolutionResponse
 	var err error
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.m.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ElasticPoolID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.ElasticPoolIDRef,
+			Selector:     mg.Spec.ForProvider.ElasticPoolIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.ElasticPoolID")
+	}
+	mg.Spec.ForProvider.ElasticPoolID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ElasticPoolIDRef = rsp.ResolvedReference
 
 	if mg.Spec.ForProvider.Identity != nil {
 		{
@@ -88,6 +108,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	}
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.m.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ElasticPoolID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.ElasticPoolIDRef,
+			Selector:     mg.Spec.InitProvider.ElasticPoolIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.ElasticPoolID")
+	}
+	mg.Spec.InitProvider.ElasticPoolID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.ElasticPoolIDRef = rsp.ResolvedReference
 
 	if mg.Spec.InitProvider.Identity != nil {
 		{

--- a/apis/namespaced/sql/v1beta1/zz_mssqldatabase_types.go
+++ b/apis/namespaced/sql/v1beta1/zz_mssqldatabase_types.go
@@ -213,7 +213,17 @@ type MSSQLDatabaseInitParameters struct {
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
 
 	// Specifies the ID of the elastic pool containing this database.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/sql/v1beta1.MSSQLElasticPool
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/namespaced/rconfig.ExtractResourceID()
 	ElasticPoolID *string `json:"elasticPoolId,omitempty" tf:"elastic_pool_id,omitempty"`
+
+	// Reference to a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDRef *v1.NamespacedReference `json:"elasticPoolIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDSelector *v1.NamespacedSelector `json:"elasticPoolIdSelector,omitempty" tf:"-"`
 
 	// Specifies the type of enclave to be used by the elastic pool. When enclave_type is not specified (e.g., the default) enclaves are not enabled on the database. Once enabled (e.g., by specifying Default or VBS) removing the enclave_type field from the configuration file will force the creation of a new resource. Possible values are Default or VBS.
 	EnclaveType *string `json:"enclaveType,omitempty" tf:"enclave_type,omitempty"`
@@ -439,8 +449,18 @@ type MSSQLDatabaseParameters struct {
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
 
 	// Specifies the ID of the elastic pool containing this database.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/sql/v1beta1.MSSQLElasticPool
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/namespaced/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	ElasticPoolID *string `json:"elasticPoolId,omitempty" tf:"elastic_pool_id,omitempty"`
+
+	// Reference to a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDRef *v1.NamespacedReference `json:"elasticPoolIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLElasticPool in sql to populate elasticPoolId.
+	// +kubebuilder:validation:Optional
+	ElasticPoolIDSelector *v1.NamespacedSelector `json:"elasticPoolIdSelector,omitempty" tf:"-"`
 
 	// Specifies the type of enclave to be used by the elastic pool. When enclave_type is not specified (e.g., the default) enclaves are not enabled on the database. Once enabled (e.g., by specifying Default or VBS) removing the enclave_type field from the configuration file will force the creation of a new resource. Possible values are Default or VBS.
 	// +kubebuilder:validation:Optional

--- a/config/cluster/sql/config.go
+++ b/config/cluster/sql/config.go
@@ -126,6 +126,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_mssql_server",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.References["elastic_pool_id"] = config.Reference{
+			TerraformName: "azurerm_mssql_elasticpool",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
+		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"maintenance_configuration_name", "elastic_pool_id"},
 		}

--- a/config/namespaced/sql/config.go
+++ b/config/namespaced/sql/config.go
@@ -126,6 +126,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_mssql_server",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.References["elastic_pool_id"] = config.Reference{
+			TerraformName: "azurerm_mssql_elasticpool",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
+		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"maintenance_configuration_name", "elastic_pool_id"},
 		}

--- a/examples/sql/cluster/v1beta2/mssqldatabase.yaml
+++ b/examples/sql/cluster/v1beta2/mssqldatabase.yaml
@@ -8,22 +8,49 @@ metadata:
   annotations:
     meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: examplemssqldatabase
+  name: examplemssqldatabase
 spec:
   forProvider:
     collation: SQL_Latin1_General_CP1_CI_AS
-    enclaveType: VBS
-    licenseType: LicenseIncluded
-    maxSizeGb: 4
-    readScale: true
+    elasticPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasepool
     serverIdSelector:
       matchLabels:
-        testing.upbound.io/example-name: example
-    skuName: S0
+        testing.upbound.io/example-name: mssqldatabasesrv
+    skuName: ElasticPool
     tags:
       foo: bar
-    zoneRedundant: true
+
+---
+
+apiVersion: sql.azure.upbound.io/v1beta2
+kind: MSSQLElasticPool
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
+  labels:
+    testing.upbound.io/example-name: mssqldatabasepool
+  name: mssqldatabasepool
+spec:
+  forProvider:
+    location: West Europe
+    maxSizeGb: 5
+    perDatabaseSettings:
+      maxCapacity: 4
+      minCapacity: 1
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabase-rg
+    serverNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasesrv
+    sku:
+      capacity: 4
+      family: Gen5
+      name: GP_Gen5
+      tier: GeneralPurpose
 
 ---
 
@@ -32,9 +59,10 @@ kind: MSSQLServer
 metadata:
   annotations:
     meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
+    uptest.upbound.io/timeout: "3600"
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: mssqldatabasesrv
+  name: sqldatabasev1beta2
 spec:
   forProvider:
     administratorLogin: 4dm1n157r470r
@@ -45,7 +73,7 @@ spec:
     location: West Europe
     resourceGroupNameSelector:
       matchLabels:
-        testing.upbound.io/example-name: example
+        testing.upbound.io/example-name: mssqldatabase-rg
     version: "12.0"
 
 ---
@@ -56,27 +84,19 @@ metadata:
   annotations:
     meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: mssqldatabase-rg
+  name: sqldatabasev1beta2
 spec:
   forProvider:
     location: West Europe
 
 ---
 
-apiVersion: storage.azure.upbound.io/v1beta2
-kind: Account
+apiVersion: v1
+data:
+  example-key: dGVzdFBhc3N3b3JkITEyMw==
+kind: Secret
 metadata:
-  annotations:
-    meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
-  labels:
-    testing.upbound.io/example-name: example
-  name: example
-spec:
-  forProvider:
-    accountReplicationType: LRS
-    accountTier: Standard
-    location: West Europe
-    resourceGroupNameSelector:
-      matchLabels:
-        testing.upbound.io/example-name: example
+  name: example-secret
+  namespace: upbound-system
+type: Opaque

--- a/examples/sql/namespaced/v1beta1/mssqldatabase.yaml
+++ b/examples/sql/namespaced/v1beta1/mssqldatabase.yaml
@@ -8,32 +8,59 @@ metadata:
   annotations:
     meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: examplemssqldatabase
+  name: examplemssqldatabase
   namespace: upbound-system
 spec:
   forProvider:
     collation: SQL_Latin1_General_CP1_CI_AS
-    enclaveType: VBS
-    licenseType: LicenseIncluded
-    maxSizeGb: 4
-    readScale: true
+    elasticPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasepool
     serverIdSelector:
       matchLabels:
-        testing.upbound.io/example-name: example
-    skuName: S0
+        testing.upbound.io/example-name: mssqldatabasesrv
+    skuName: ElasticPool
     tags:
       foo: bar
-    zoneRedundant: true
+---
+apiVersion: sql.azure.m.upbound.io/v1beta1
+kind: MSSQLElasticPool
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
+  labels:
+    testing.upbound.io/example-name: mssqldatabasepool
+  name: mssqldatabasepool
+  namespace: upbound-system
+spec:
+  forProvider:
+    location: West Europe
+    maxSizeGb: 5
+    perDatabaseSettings:
+      maxCapacity: 4
+      minCapacity: 1
+    resourceGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabase-rg
+    serverNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasesrv
+    sku:
+      capacity: 4
+      family: Gen5
+      name: GP_Gen5
+      tier: GeneralPurpose
 ---
 apiVersion: sql.azure.m.upbound.io/v1beta1
 kind: MSSQLServer
 metadata:
   annotations:
     meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
+    uptest.upbound.io/timeout: "3600"
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: mssqldatabasesrv
+  name: sqldatabasev1beta1ns
   namespace: upbound-system
 spec:
   forProvider:
@@ -44,7 +71,7 @@ spec:
     location: West Europe
     resourceGroupNameSelector:
       matchLabels:
-        testing.upbound.io/example-name: example
+        testing.upbound.io/example-name: mssqldatabase-rg
     version: "12.0"
 ---
 apiVersion: azure.m.upbound.io/v1beta1
@@ -53,27 +80,18 @@ metadata:
   annotations:
     meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
   labels:
-    testing.upbound.io/example-name: example
-  name: example
+    testing.upbound.io/example-name: mssqldatabase-rg
+  name: sqldatabasev1beta1ns
   namespace: upbound-system
 spec:
   forProvider:
     location: West Europe
 ---
-apiVersion: storage.azure.m.upbound.io/v1beta1
-kind: Account
+apiVersion: v1
+data:
+  example-key: dGVzdFBhc3N3b3JkITEyMw==
+kind: Secret
 metadata:
-  annotations:
-    meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
-  labels:
-    testing.upbound.io/example-name: example
-  name: example
+  name: example-secret
   namespace: upbound-system
-spec:
-  forProvider:
-    accountReplicationType: LRS
-    accountTier: Standard
-    location: West Europe
-    resourceGroupNameSelector:
-      matchLabels:
-        testing.upbound.io/example-name: example
+type: Opaque

--- a/package/crds/sql.azure.m.upbound.io_mssqldatabases.yaml
+++ b/package/crds/sql.azure.m.upbound.io_mssqldatabases.yaml
@@ -86,6 +86,88 @@ spec:
                     description: Specifies the ID of the elastic pool containing this
                       database.
                     type: string
+                  elasticPoolIdRef:
+                    description: Reference to a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  elasticPoolIdSelector:
+                    description: Selector for a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   enclaveType:
                     description: Specifies the type of enclave to be used by the elastic
                       pool. When enclave_type is not specified (e.g., the default)
@@ -668,6 +750,88 @@ spec:
                     description: Specifies the ID of the elastic pool containing this
                       database.
                     type: string
+                  elasticPoolIdRef:
+                    description: Reference to a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  elasticPoolIdSelector:
+                    description: Selector for a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   enclaveType:
                     description: Specifies the type of enclave to be used by the elastic
                       pool. When enclave_type is not specified (e.g., the default)

--- a/package/crds/sql.azure.upbound.io_mssqldatabases.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqldatabases.yaml
@@ -100,6 +100,82 @@ spec:
                     description: Specifies the ID of the elastic pool containing this
                       database.
                     type: string
+                  elasticPoolIdRef:
+                    description: Reference to a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  elasticPoolIdSelector:
+                    description: Selector for a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   enclaveType:
                     description: Specifies the type of enclave to be used by the database.
                       Possible value VBS.
@@ -686,6 +762,82 @@ spec:
                     description: Specifies the ID of the elastic pool containing this
                       database.
                     type: string
+                  elasticPoolIdRef:
+                    description: Reference to a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  elasticPoolIdSelector:
+                    description: Selector for a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   enclaveType:
                     description: Specifies the type of enclave to be used by the database.
                       Possible value VBS.
@@ -1644,6 +1796,82 @@ spec:
                     description: Specifies the ID of the elastic pool containing this
                       database.
                     type: string
+                  elasticPoolIdRef:
+                    description: Reference to a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  elasticPoolIdSelector:
+                    description: Selector for a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   enclaveType:
                     description: Specifies the type of enclave to be used by the elastic
                       pool. When enclave_type is not specified (e.g., the default)
@@ -2223,6 +2451,82 @@ spec:
                     description: Specifies the ID of the elastic pool containing this
                       database.
                     type: string
+                  elasticPoolIdRef:
+                    description: Reference to a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  elasticPoolIdSelector:
+                    description: Selector for a MSSQLElasticPool in sql to populate
+                      elasticPoolId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   enclaveType:
                     description: Specifies the type of enclave to be used by the elastic
                       pool. When enclave_type is not specified (e.g., the default)


### PR DESCRIPTION
## Summary

- Add `elasticPoolIdRef` and `elasticPoolIdSelector` support to `MSSQLDatabase`, allowing declarative references to `MSSQLElasticPool` resources instead of requiring hard-coded Azure resource IDs
- Follows the same pattern already used for `serverIdRef`/`serverIdSelector`

Fixes #1197

## Test plan

- [x] Verify code generation produces the expected `elasticPoolIdRef` and `elasticPoolIdSelector` fields in the CRD types
- [ ] Validate that referencing an `MSSQLElasticPool` by name resolves correctly