### PR TITLE
Add `--all-namespaces` to Uptest cleanup

### DIFF
--- a/.github/workflows/uptest-trigger.yml
+++ b/.github/workflows/uptest-trigger.yml
@@ -171,7 +171,7 @@ jobs:
         if: always()
         run: |
           eval $(make --no-print-directory build.vars)
-          ${KUBECTL} delete managed --all || true
+          ${KUBECTL} delete managed --all --all-namespaces || true
 
       - name: Create Unsuccessful Status Check
         if: failure()


### PR DESCRIPTION
### Description of your changes
The script does not clean up after e2e tests of namespaced resources because there's a namespace selector missing - ${KUBECTL} delete managed --all || true. That has led to some resources not being cleaned up after previous e2e tests and blocking new test executions

I have:

- [X] Read and followed Crossplane's [contribution process].
~- [ ] Run `make reviewable` to ensure this PR is ready for review.~

### How has this code been tested

[contribution process]: https://git.io/fj2m9
