### PR TITLE
Add creation source database reference support to MSSQLDatabase

### DIFF
--- a/apis/cluster/sql/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/sql/v1beta1/zz_generated.deepcopy.go
@@ -1036,6 +1036,16 @@ func (in *MSSQLDatabaseInitParameters) DeepCopyInto(out *MSSQLDatabaseInitParame
 		*out = new(string)
 		**out = **in
 	}
+	if in.CreationSourceDatabaseIDRef != nil {
+		in, out := &in.CreationSourceDatabaseIDRef, &out.CreationSourceDatabaseIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CreationSourceDatabaseIDSelector != nil {
+		in, out := &in.CreationSourceDatabaseIDSelector, &out.CreationSourceDatabaseIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ElasticPoolID != nil {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID
 		*out = new(string)
@@ -1499,6 +1509,16 @@ func (in *MSSQLDatabaseParameters) DeepCopyInto(out *MSSQLDatabaseParameters) {
 		in, out := &in.CreationSourceDatabaseID, &out.CreationSourceDatabaseID
 		*out = new(string)
 		**out = **in
+	}
+	if in.CreationSourceDatabaseIDRef != nil {
+		in, out := &in.CreationSourceDatabaseIDRef, &out.CreationSourceDatabaseIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CreationSourceDatabaseIDSelector != nil {
+		in, out := &in.CreationSourceDatabaseIDSelector, &out.CreationSourceDatabaseIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ElasticPoolID != nil {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID

--- a/apis/cluster/sql/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/sql/v1beta1/zz_generated.resolvers.go
@@ -27,6 +27,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	var mrsp reference.MultiResolutionResponse
 	var err error
 	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta1", "MSSQLDatabase", "MSSQLDatabaseList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.CreationSourceDatabaseID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.CreationSourceDatabaseIDRef,
+			Selector:     mg.Spec.ForProvider.CreationSourceDatabaseIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.CreationSourceDatabaseID")
+	}
+	mg.Spec.ForProvider.CreationSourceDatabaseID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.CreationSourceDatabaseIDRef = rsp.ResolvedReference
+	{
 		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
@@ -108,6 +128,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	}
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta1", "MSSQLDatabase", "MSSQLDatabaseList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.CreationSourceDatabaseID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.CreationSourceDatabaseIDRef,
+			Selector:     mg.Spec.InitProvider.CreationSourceDatabaseIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.CreationSourceDatabaseID")
+	}
+	mg.Spec.InitProvider.CreationSourceDatabaseID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.CreationSourceDatabaseIDRef = rsp.ResolvedReference
 	{
 		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
 		if err != nil {

--- a/apis/cluster/sql/v1beta1/zz_mssqldatabase_types.go
+++ b/apis/cluster/sql/v1beta1/zz_mssqldatabase_types.go
@@ -209,7 +209,17 @@ type MSSQLDatabaseInitParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// The ID of the source database from which to create the new database. This should only be used for databases with create_mode values that use another database as reference. Changing this forces a new resource to be created.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta1.MSSQLDatabase
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
+
+	// Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDRef *v1.Reference `json:"creationSourceDatabaseIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDSelector *v1.Selector `json:"creationSourceDatabaseIdSelector,omitempty" tf:"-"`
 
 	// Specifies the ID of the elastic pool containing this database.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta1.MSSQLElasticPool
@@ -444,8 +454,18 @@ type MSSQLDatabaseParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// The ID of the source database from which to create the new database. This should only be used for databases with create_mode values that use another database as reference. Changing this forces a new resource to be created.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta1.MSSQLDatabase
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
+
+	// Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDRef *v1.Reference `json:"creationSourceDatabaseIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDSelector *v1.Selector `json:"creationSourceDatabaseIdSelector,omitempty" tf:"-"`
 
 	// Specifies the ID of the elastic pool containing this database.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta1.MSSQLElasticPool

--- a/apis/cluster/sql/v1beta2/zz_generated.deepcopy.go
+++ b/apis/cluster/sql/v1beta2/zz_generated.deepcopy.go
@@ -689,6 +689,16 @@ func (in *MSSQLDatabaseInitParameters) DeepCopyInto(out *MSSQLDatabaseInitParame
 		*out = new(string)
 		**out = **in
 	}
+	if in.CreationSourceDatabaseIDRef != nil {
+		in, out := &in.CreationSourceDatabaseIDRef, &out.CreationSourceDatabaseIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CreationSourceDatabaseIDSelector != nil {
+		in, out := &in.CreationSourceDatabaseIDSelector, &out.CreationSourceDatabaseIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ElasticPoolID != nil {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID
 		*out = new(string)
@@ -1132,6 +1142,16 @@ func (in *MSSQLDatabaseParameters) DeepCopyInto(out *MSSQLDatabaseParameters) {
 		in, out := &in.CreationSourceDatabaseID, &out.CreationSourceDatabaseID
 		*out = new(string)
 		**out = **in
+	}
+	if in.CreationSourceDatabaseIDRef != nil {
+		in, out := &in.CreationSourceDatabaseIDRef, &out.CreationSourceDatabaseIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CreationSourceDatabaseIDSelector != nil {
+		in, out := &in.CreationSourceDatabaseIDSelector, &out.CreationSourceDatabaseIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ElasticPoolID != nil {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID

--- a/apis/cluster/sql/v1beta2/zz_generated.resolvers.go
+++ b/apis/cluster/sql/v1beta2/zz_generated.resolvers.go
@@ -27,6 +27,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	var mrsp reference.MultiResolutionResponse
 	var err error
 	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta2", "MSSQLDatabase", "MSSQLDatabaseList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.CreationSourceDatabaseID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.CreationSourceDatabaseIDRef,
+			Selector:     mg.Spec.ForProvider.CreationSourceDatabaseIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.CreationSourceDatabaseID")
+	}
+	mg.Spec.ForProvider.CreationSourceDatabaseID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.CreationSourceDatabaseIDRef = rsp.ResolvedReference
+	{
 		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta2", "MSSQLElasticPool", "MSSQLElasticPoolList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
@@ -108,6 +128,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	}
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta2", "MSSQLDatabase", "MSSQLDatabaseList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.CreationSourceDatabaseID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.CreationSourceDatabaseIDRef,
+			Selector:     mg.Spec.InitProvider.CreationSourceDatabaseIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.CreationSourceDatabaseID")
+	}
+	mg.Spec.InitProvider.CreationSourceDatabaseID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.CreationSourceDatabaseIDRef = rsp.ResolvedReference
 	{
 		m, l, err = apisresolver.GetManagedResource("sql.azure.upbound.io", "v1beta2", "MSSQLElasticPool", "MSSQLElasticPoolList")
 		if err != nil {

--- a/apis/cluster/sql/v1beta2/zz_mssqldatabase_types.go
+++ b/apis/cluster/sql/v1beta2/zz_mssqldatabase_types.go
@@ -209,7 +209,17 @@ type MSSQLDatabaseInitParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// The ID of the source database from which to create the new database. This should only be used for databases with create_mode values that use another database as reference. Changing this forces a new resource to be created.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta2.MSSQLDatabase
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
+
+	// Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDRef *v1.Reference `json:"creationSourceDatabaseIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDSelector *v1.Selector `json:"creationSourceDatabaseIdSelector,omitempty" tf:"-"`
 
 	// Specifies the ID of the elastic pool containing this database.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta2.MSSQLElasticPool
@@ -444,8 +454,18 @@ type MSSQLDatabaseParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// The ID of the source database from which to create the new database. This should only be used for databases with create_mode values that use another database as reference. Changing this forces a new resource to be created.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta2.MSSQLDatabase
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/cluster/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
+
+	// Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDRef *v1.Reference `json:"creationSourceDatabaseIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDSelector *v1.Selector `json:"creationSourceDatabaseIdSelector,omitempty" tf:"-"`
 
 	// Specifies the ID of the elastic pool containing this database.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/sql/v1beta2.MSSQLElasticPool

--- a/apis/namespaced/sql/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/sql/v1beta1/zz_generated.deepcopy.go
@@ -1036,6 +1036,16 @@ func (in *MSSQLDatabaseInitParameters) DeepCopyInto(out *MSSQLDatabaseInitParame
 		*out = new(string)
 		**out = **in
 	}
+	if in.CreationSourceDatabaseIDRef != nil {
+		in, out := &in.CreationSourceDatabaseIDRef, &out.CreationSourceDatabaseIDRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CreationSourceDatabaseIDSelector != nil {
+		in, out := &in.CreationSourceDatabaseIDSelector, &out.CreationSourceDatabaseIDSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ElasticPoolID != nil {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID
 		*out = new(string)
@@ -1479,6 +1489,16 @@ func (in *MSSQLDatabaseParameters) DeepCopyInto(out *MSSQLDatabaseParameters) {
 		in, out := &in.CreationSourceDatabaseID, &out.CreationSourceDatabaseID
 		*out = new(string)
 		**out = **in
+	}
+	if in.CreationSourceDatabaseIDRef != nil {
+		in, out := &in.CreationSourceDatabaseIDRef, &out.CreationSourceDatabaseIDRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CreationSourceDatabaseIDSelector != nil {
+		in, out := &in.CreationSourceDatabaseIDSelector, &out.CreationSourceDatabaseIDSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ElasticPoolID != nil {
 		in, out := &in.ElasticPoolID, &out.ElasticPoolID

--- a/apis/namespaced/sql/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/sql/v1beta1/zz_generated.resolvers.go
@@ -27,6 +27,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	var mrsp reference.MultiNamespacedResolutionResponse
 	var err error
 	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.m.upbound.io", "v1beta1", "MSSQLDatabase", "MSSQLDatabaseList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.CreationSourceDatabaseID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.ForProvider.CreationSourceDatabaseIDRef,
+			Selector:     mg.Spec.ForProvider.CreationSourceDatabaseIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.CreationSourceDatabaseID")
+	}
+	mg.Spec.ForProvider.CreationSourceDatabaseID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.CreationSourceDatabaseIDRef = rsp.ResolvedReference
+	{
 		m, l, err = apisresolver.GetManagedResource("sql.azure.m.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
@@ -108,6 +128,26 @@ func (mg *MSSQLDatabase) ResolveReferences( // ResolveReferences of this MSSQLDa
 	}
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.TransparentDataEncryptionKeyVaultKeyIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("sql.azure.m.upbound.io", "v1beta1", "MSSQLDatabase", "MSSQLDatabaseList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.CreationSourceDatabaseID),
+			Extract:      rconfig.ExtractResourceID(),
+			Namespace:    mg.GetNamespace(),
+			Reference:    mg.Spec.InitProvider.CreationSourceDatabaseIDRef,
+			Selector:     mg.Spec.InitProvider.CreationSourceDatabaseIDSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.CreationSourceDatabaseID")
+	}
+	mg.Spec.InitProvider.CreationSourceDatabaseID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.CreationSourceDatabaseIDRef = rsp.ResolvedReference
 	{
 		m, l, err = apisresolver.GetManagedResource("sql.azure.m.upbound.io", "v1beta1", "MSSQLElasticPool", "MSSQLElasticPoolList")
 		if err != nil {

--- a/apis/namespaced/sql/v1beta1/zz_mssqldatabase_types.go
+++ b/apis/namespaced/sql/v1beta1/zz_mssqldatabase_types.go
@@ -210,7 +210,17 @@ type MSSQLDatabaseInitParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// The ID of the source database from which to create the new database. This should only be used for databases with create_mode values that use another database as reference. Changing this forces a new resource to be created.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/sql/v1beta1.MSSQLDatabase
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/namespaced/rconfig.ExtractResourceID()
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
+
+	// Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDRef *v1.NamespacedReference `json:"creationSourceDatabaseIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDSelector *v1.NamespacedSelector `json:"creationSourceDatabaseIdSelector,omitempty" tf:"-"`
 
 	// Specifies the ID of the elastic pool containing this database.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/sql/v1beta1.MSSQLElasticPool
@@ -445,8 +455,18 @@ type MSSQLDatabaseParameters struct {
 	CreateMode *string `json:"createMode,omitempty" tf:"create_mode,omitempty"`
 
 	// The ID of the source database from which to create the new database. This should only be used for databases with create_mode values that use another database as reference. Changing this forces a new resource to be created.
+	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/sql/v1beta1.MSSQLDatabase
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-azure/v2/apis/namespaced/rconfig.ExtractResourceID()
 	// +kubebuilder:validation:Optional
 	CreationSourceDatabaseID *string `json:"creationSourceDatabaseId,omitempty" tf:"creation_source_database_id,omitempty"`
+
+	// Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDRef *v1.NamespacedReference `json:"creationSourceDatabaseIdRef,omitempty" tf:"-"`
+
+	// Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+	// +kubebuilder:validation:Optional
+	CreationSourceDatabaseIDSelector *v1.NamespacedSelector `json:"creationSourceDatabaseIdSelector,omitempty" tf:"-"`
 
 	// Specifies the ID of the elastic pool containing this database.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/sql/v1beta1.MSSQLElasticPool

--- a/config/cluster/sql/config.go
+++ b/config/cluster/sql/config.go
@@ -130,6 +130,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_mssql_elasticpool",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.References["creation_source_database_id"] = config.Reference{
+			TerraformName: "azurerm_mssql_database",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
+		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"maintenance_configuration_name", "elastic_pool_id"},
 		}

--- a/config/namespaced/sql/config.go
+++ b/config/namespaced/sql/config.go
@@ -130,6 +130,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "azurerm_mssql_elasticpool",
 			Extractor:     rconfig.ExtractResourceIDFuncPath,
 		}
+		r.References["creation_source_database_id"] = config.Reference{
+			TerraformName: "azurerm_mssql_database",
+			Extractor:     rconfig.ExtractResourceIDFuncPath,
+		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"maintenance_configuration_name", "elastic_pool_id"},
 		}

--- a/examples/sql/cluster/v1beta2/mssqldatabase.yaml
+++ b/examples/sql/cluster/v1beta2/mssqldatabase.yaml
@@ -92,6 +92,32 @@ spec:
 
 ---
 
+apiVersion: sql.azure.upbound.io/v1beta2
+kind: MSSQLDatabase
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
+  labels:
+    testing.upbound.io/example-name: examplemssqldatabasecopy
+  name: examplemssqldatabasecopy
+spec:
+  forProvider:
+    collation: SQL_Latin1_General_CP1_CI_AS
+    createMode: Copy
+    creationSourceDatabaseIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: examplemssqldatabase
+    elasticPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasepool
+    serverIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasesrv
+    tags:
+      foo: bar
+
+---
+
 apiVersion: v1
 data:
   example-key: dGVzdFBhc3N3b3JkITEyMw==

--- a/examples/sql/namespaced/v1beta1/mssqldatabase.yaml
+++ b/examples/sql/namespaced/v1beta1/mssqldatabase.yaml
@@ -87,6 +87,31 @@ spec:
   forProvider:
     location: West Europe
 ---
+apiVersion: sql.azure.m.upbound.io/v1beta1
+kind: MSSQLDatabase
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sql/v1beta2/mssqldatabase
+  labels:
+    testing.upbound.io/example-name: examplemssqldatabasecopy
+  name: examplemssqldatabasecopy
+  namespace: upbound-system
+spec:
+  forProvider:
+    collation: SQL_Latin1_General_CP1_CI_AS
+    createMode: Copy
+    creationSourceDatabaseIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: examplemssqldatabase
+    elasticPoolIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasepool
+    serverIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: mssqldatabasesrv
+    tags:
+      foo: bar
+---
 apiVersion: v1
 data:
   example-key: dGVzdFBhc3N3b3JkITEyMw==

--- a/package/crds/sql.azure.m.upbound.io_mssqldatabases.yaml
+++ b/package/crds/sql.azure.m.upbound.io_mssqldatabases.yaml
@@ -82,6 +82,86 @@ spec:
                       create_mode values that use another database as reference. Changing
                       this forces a new resource to be created.
                     type: string
+                  creationSourceDatabaseIdRef:
+                    description: Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  creationSourceDatabaseIdSelector:
+                    description: Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   elasticPoolId:
                     description: Specifies the ID of the elastic pool containing this
                       database.
@@ -746,6 +826,86 @@ spec:
                       create_mode values that use another database as reference. Changing
                       this forces a new resource to be created.
                     type: string
+                  creationSourceDatabaseIdRef:
+                    description: Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  creationSourceDatabaseIdSelector:
+                    description: Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   elasticPoolId:
                     description: Specifies the ID of the elastic pool containing this
                       database.

--- a/package/crds/sql.azure.upbound.io_mssqldatabases.yaml
+++ b/package/crds/sql.azure.upbound.io_mssqldatabases.yaml
@@ -99,6 +99,80 @@ spec:
                       create_mode values that use another database as reference. Changing
                       this forces a new resource to be created.
                     type: string
+                  creationSourceDatabaseIdRef:
+                    description: Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  creationSourceDatabaseIdSelector:
+                    description: Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   elasticPoolId:
                     description: Specifies the ID of the elastic pool containing this
                       database.
@@ -761,6 +835,80 @@ spec:
                       create_mode values that use another database as reference. Changing
                       this forces a new resource to be created.
                     type: string
+                  creationSourceDatabaseIdRef:
+                    description: Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  creationSourceDatabaseIdSelector:
+                    description: Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   elasticPoolId:
                     description: Specifies the ID of the elastic pool containing this
                       database.
@@ -1832,6 +1980,80 @@ spec:
                       create_mode values that use another database as reference. Changing
                       this forces a new resource to be created.
                     type: string
+                  creationSourceDatabaseIdRef:
+                    description: Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  creationSourceDatabaseIdSelector:
+                    description: Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   elasticPoolId:
                     description: Specifies the ID of the elastic pool containing this
                       database.
@@ -2487,6 +2709,80 @@ spec:
                       create_mode values that use another database as reference. Changing
                       this forces a new resource to be created.
                     type: string
+                  creationSourceDatabaseIdRef:
+                    description: Reference to a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  creationSourceDatabaseIdSelector:
+                    description: Selector for a MSSQLDatabase in sql to populate creationSourceDatabaseId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   elasticPoolId:
                     description: Specifies the ID of the elastic pool containing this
                       database.


### PR DESCRIPTION
## Summary

Add `creationSourceDatabaseIdRef`/`creationSourceDatabaseIdSelector` support to `MSSQLDatabase`, allowing declarative references to another `MSSQLDatabase` resource instead of requiring a hard-coded Azure resource ID for `creationSourceDatabaseId`.

`creationSourceDatabaseId` is used together with `createMode` values that seed a new database from an existing one (`Copy`, `Secondary`, `PointInTimeRestore`, etc.). Today users must paste the raw Azure resource ID of the source database; this change lets them point at the source `MSSQLDatabase` managed resource by name or label and have Crossplane resolve the ID.

Follows the same pattern recently added for `elasticPoolIdRef`/`elasticPoolIdSelector` (#1198) and the existing `serverIdRef`/`serverIdSelector`.

## What Changed

- **Reference config**: Add a `creation_source_database_id` reference pointing to `azurerm_mssql_database` (a self-reference to the same resource type) in both the cluster and namespaced provider configs (`config/cluster/sql/config.go`, `config/namespaced/sql/config.go`), using the same `ExtractResourceIDFuncPath` extractor as the existing references.
- **v1beta1 backport**: Backport the reference markers and `Ref`/`Selector` fields to cluster `sql/v1beta1` (`InitParameters` and `Parameters` only, not `Observation`), matching how the elastic pool reference was backported.
- **Generated code**: Regenerate CRDs, types, resolvers, and deepcopy methods across cluster `v1beta2`/`v1beta1` and namespaced `v1beta1`.
- **Examples**: Add a second `MSSQLDatabase` (`examplemssqldatabasecopy`) to both example files that uses `createMode: Copy` and `creationSourceDatabaseIdSelector` to reference the primary database, exercising the new reference.

## Reviewer Guide

- **Start here**: The only hand-written change is the `creation_source_database_id` reference block in `config/cluster/sql/config.go` and `config/namespaced/sql/config.go`. Everything else is generated or the v1beta1 backport markers.
- **Pay attention to**: The reference target is `azurerm_mssql_database` itself — a self-reference. This is intentional (a copied/restored database references the source database).
- **Design decision**: v1beta1 is no longer regenerated from the Terraform schema, so the reference markers + `Ref`/`Selector` fields were added manually to the v1beta1 types and the resolvers/deepcopy were regenerated from those markers — same approach used for `elasticPoolId` in #1198.

## Testing Plan

### Happy Path
- [ ] Code generation produces `creationSourceDatabaseIdRef`/`creationSourceDatabaseIdSelector` in the CRD types and CRDs (`make generate` is a no-op on a clean checkout of this branch).
- [ ] Apply the updated `examples/sql/cluster/v1beta2/mssqldatabase.yaml`; confirm `examplemssqldatabasecopy` resolves `creationSourceDatabaseId` from `examplemssqldatabase` and becomes ready.

### Edge Cases
- [ ] Verify the copy database waits for the source database to have an ID before resolving (reference ordering).
- [ ] Validate the copy's SKU is compatible with `createMode: Copy` given the source sits in an elastic pool; adjust `skuName`/placement if Azure rejects the combination.

### Regression Checks
- [ ] Existing `serverId`/`elasticPoolId` reference resolution on `MSSQLDatabase` still works unchanged.