### PR TITLE
Implement `upjet_resource_external_api_calls_total` metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -205,4 +205,4 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.6.0 // indirect
 )
 
-replace github.com/hashicorp/terraform-provider-azurerm => github.com/upbound/terraform-provider-azurerm v0.0.0-20251127122522-9029e3f708c4
+replace github.com/hashicorp/terraform-provider-azurerm => github.com/upbound/terraform-provider-azurerm v0.0.0-20260701132458-81005aad06a2

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uL
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/upbound/terraform-provider-azurerm v0.0.0-20251127122522-9029e3f708c4 h1:eX9OaivTUlfNUCxF7Ef+0S5JgSIX/OtNfxkAVL30Uxw=
-github.com/upbound/terraform-provider-azurerm v0.0.0-20251127122522-9029e3f708c4/go.mod h1:dWD0SAZY3hcP0axq55ElyIyMTM+xTg8MI2BSGSEG1kw=
+github.com/upbound/terraform-provider-azurerm v0.0.0-20260701132458-81005aad06a2 h1:XMvUyeCfldfhWUNRhO+IonJAwY4VD0c4Jg6Kqsav9Is=
+github.com/upbound/terraform-provider-azurerm v0.0.0-20260701132458-81005aad06a2/go.mod h1:dWD0SAZY3hcP0axq55ElyIyMTM+xTg8MI2BSGSEG1kw=
 github.com/upbound/uptest v0.12.1-0.20260123170102-8965579a213b h1:3skJb1zt9rBR/4wUWMT32Ip02OckGzYyMhjCkEeCdfA=
 github.com/upbound/uptest v0.12.1-0.20260123170102-8965579a213b/go.mod h1:LaaCdCFepE8h8UtssvRbKBgrNUK4CKNh+bEyE0HnLvc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/clients/azure.go
+++ b/internal/clients/azure.go
@@ -7,6 +7,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"sync/atomic"
 
@@ -15,7 +16,9 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	upjetmetrics "github.com/crossplane/upjet/v2/pkg/metrics"
 	"github.com/crossplane/upjet/v2/pkg/terraform"
+	tfazureclient "github.com/hashicorp/terraform-provider-azurerm/xpprovider"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,6 +76,33 @@ var (
 	// Round-robin counter for service principal selection
 	servicePrincipalCounter uint64
 )
+
+// armServiceFromPath extracts a short service label from an ARM request path.
+//
+// Priority order:
+//  1. Resource provider namespace after /providers/ (most specific):
+//     .../providers/Microsoft.Compute/... → "Microsoft.Compute"
+//  2. Collection name after /subscriptions/{sub}/:
+//     /subscriptions/{sub}/resourceGroups/... → "resourceGroups"
+//     /subscriptions/{sub}                    → "subscriptions"
+//  3. "unknown" for anything else (e.g. data-plane endpoints)
+func armServiceFromPath(path string) string {
+	if _, after, ok := strings.Cut(path, "/providers/"); ok {
+		if ns, _, _ := strings.Cut(after, "/"); ns != "" {
+			return ns
+		}
+	}
+	if _, after, ok := strings.Cut(path, "/subscriptions/"); ok {
+		_, rest, found := strings.Cut(after, "/")
+		if !found {
+			return "subscriptions"
+		}
+		if seg, _, _ := strings.Cut(rest, "/"); seg != "" {
+			return seg
+		}
+	}
+	return "unknown"
+}
 
 // TerraformSetupBuilder returns Terraform setup with provider specific
 // configuration like provider credentials used to connect to cloud APIs in the
@@ -136,6 +166,15 @@ func configureNoForkAzureClient(ctx context.Context, ps *terraform.Setup, p sche
 		return errors.Errorf("failed to configure the provider: %v", diag)
 	}
 	ps.Meta = p.Meta()
+	// RegisterResponseMiddleware will increment the `external_api_calls_total` metric multiple times if the request is retried e.g. as a result of HTTP 429
+	// It will NOT increment the metric if we do not receive a response back e.g. connection failure
+	tfazureclient.RegisterResponseMiddleware(ps.Meta, func(req *http.Request, resp *http.Response) (*http.Response, error) {
+		if req == nil || req.URL == nil || resp == nil {
+			return resp, nil
+		}
+		upjetmetrics.ExternalAPICalls.WithLabelValues(armServiceFromPath(req.URL.Path), req.Method).Inc()
+		return resp, nil
+	})
 	return nil
 }
 

--- a/internal/clients/azure_test.go
+++ b/internal/clients/azure_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_armServiceFromPath(t *testing.T) {
+	cases := map[string]struct {
+		path string
+		want string
+	}{
+		"arm_service_namespace_exists": {
+			path: "/subscriptions/sub1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			want: "Microsoft.Compute",
+		},
+		"no_arm_service_resource_group": {
+			path: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg",
+			want: "resourceGroups",
+		},
+		"no_arm_service_resource_group_collection": {
+			path: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups",
+			want: "resourceGroups",
+		},
+		"no_arm_service_subscription": {
+			path: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			want: "subscriptions",
+		},
+		"not_valid_arm_service": {
+			path: "/some/random/path",
+			want: "unknown",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := armServiceFromPath(tc.path)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("armServiceFromPath(%q) mismatch (-want +got):\n%s", tc.path, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes
I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested manually - example metric:

```shell
judasz@Jonaszs-MacBook-Pro provider-upjet-azure % curl localhost:8080/metrics | rg "upjet_resource_external_api_calls_total"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP upjet_resource_external_api_calls_total The number of external API calls.
# TYPE upjet_resource_external_api_calls_total counter
upjet_resource_external_api_calls_total{operation="DELETE",service="Microsoft.Network"} 1
upjet_resource_external_api_calls_total{operation="GET",service="Microsoft.Network"} 3
100 2124k    0 2124k    0     0   117M      0 --:--:-- --:--:-- --:--:--  122M
```

[contribution process]: https://git.io/fj2m9
