### PR TITLE
docs(containerapp): fix CustomDomain certificate field descriptions

### DIFF
--- a/apis/cluster/containerapp/v1beta1/zz_customdomain_types.go
+++ b/apis/cluster/containerapp/v1beta1/zz_customdomain_types.go
@@ -15,11 +15,11 @@ import (
 
 type CustomDomainInitParameters_2 struct {
 
-	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
 	// The Binding type. Possible values include `Disabled` and `SniEnabled`.
 	CertificateBindingType *string `json:"certificateBindingType,omitempty" tf:"certificate_binding_type,omitempty"`
 
-	// The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+	// The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/containerapp/v1beta1.EnvironmentCertificate
 	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
 	ContainerAppEnvironmentCertificateID *string `json:"containerAppEnvironmentCertificateId,omitempty" tf:"container_app_environment_certificate_id,omitempty"`
@@ -35,11 +35,11 @@ type CustomDomainInitParameters_2 struct {
 
 type CustomDomainObservation_2 struct {
 
-	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
 	// The Binding type. Possible values include `Disabled` and `SniEnabled`.
 	CertificateBindingType *string `json:"certificateBindingType,omitempty" tf:"certificate_binding_type,omitempty"`
 
-	// The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+	// The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 	ContainerAppEnvironmentCertificateID *string `json:"containerAppEnvironmentCertificateId,omitempty" tf:"container_app_environment_certificate_id,omitempty"`
 
 	// The ID of the Container App Environment Managed Certificate to use.
@@ -53,12 +53,12 @@ type CustomDomainObservation_2 struct {
 
 type CustomDomainParameters_2 struct {
 
-	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
 	// The Binding type. Possible values include `Disabled` and `SniEnabled`.
 	// +kubebuilder:validation:Optional
 	CertificateBindingType *string `json:"certificateBindingType,omitempty" tf:"certificate_binding_type,omitempty"`
 
-	// The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+	// The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/cluster/containerapp/v1beta1.EnvironmentCertificate
 	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/containerapp/v1beta1/zz_customdomain_types.go
+++ b/apis/namespaced/containerapp/v1beta1/zz_customdomain_types.go
@@ -15,11 +15,11 @@ import (
 
 type CustomDomainInitParameters_2 struct {
 
-	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
 	// The Binding type. Possible values include `Disabled` and `SniEnabled`.
 	CertificateBindingType *string `json:"certificateBindingType,omitempty" tf:"certificate_binding_type,omitempty"`
 
-	// The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+	// The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/containerapp/v1beta1.EnvironmentCertificate
 	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
 	ContainerAppEnvironmentCertificateID *string `json:"containerAppEnvironmentCertificateId,omitempty" tf:"container_app_environment_certificate_id,omitempty"`
@@ -35,11 +35,11 @@ type CustomDomainInitParameters_2 struct {
 
 type CustomDomainObservation_2 struct {
 
-	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
 	// The Binding type. Possible values include `Disabled` and `SniEnabled`.
 	CertificateBindingType *string `json:"certificateBindingType,omitempty" tf:"certificate_binding_type,omitempty"`
 
-	// The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+	// The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 	ContainerAppEnvironmentCertificateID *string `json:"containerAppEnvironmentCertificateId,omitempty" tf:"container_app_environment_certificate_id,omitempty"`
 
 	// The ID of the Container App Environment Managed Certificate to use.
@@ -53,12 +53,12 @@ type CustomDomainObservation_2 struct {
 
 type CustomDomainParameters_2 struct {
 
-	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+	// The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
 	// The Binding type. Possible values include `Disabled` and `SniEnabled`.
 	// +kubebuilder:validation:Optional
 	CertificateBindingType *string `json:"certificateBindingType,omitempty" tf:"certificate_binding_type,omitempty"`
 
-	// The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+	// The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azure/v2/apis/namespaced/containerapp/v1beta1.EnvironmentCertificate
 	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
 	// +kubebuilder:validation:Optional

--- a/config/cluster/containerapp/config.go
+++ b/config/cluster/containerapp/config.go
@@ -32,6 +32,12 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_container_app_custom_domain", func(r *config.Resource) {
 		r.ShortGroup = group
 		r.Kind = "CustomDomain"
+		// The scraped upstream documentation still marks these fields as
+		// immutable. The Terraform provider fork updates the certificate in
+		// place, and only clearing it forces a new resource to be created.
+		// https://github.com/upbound/terraform-provider-azurerm/pull/6
+		r.MetaResource.ArgumentDocs["certificate_binding_type"] = "- (Optional) The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id."
+		r.MetaResource.ArgumentDocs["container_app_environment_certificate_id"] = "- (Optional) The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created."
 	})
 
 	p.AddResourceConfigurator("azurerm_container_app_environment_certificate", func(r *config.Resource) {

--- a/config/namespaced/containerapp/config.go
+++ b/config/namespaced/containerapp/config.go
@@ -32,6 +32,12 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azurerm_container_app_custom_domain", func(r *config.Resource) {
 		r.ShortGroup = group
 		r.Kind = "CustomDomain"
+		// The scraped upstream documentation still marks these fields as
+		// immutable. The Terraform provider fork updates the certificate in
+		// place, and only clearing it forces a new resource to be created.
+		// https://github.com/upbound/terraform-provider-azurerm/pull/6
+		r.MetaResource.ArgumentDocs["certificate_binding_type"] = "- (Optional) The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id."
+		r.MetaResource.ArgumentDocs["container_app_environment_certificate_id"] = "- (Optional) The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created."
 	})
 
 	p.AddResourceConfigurator("azurerm_container_app_environment_certificate", func(r *config.Resource) {

--- a/package/crds/containerapp.azure.m.upbound.io_customdomains.yaml
+++ b/package/crds/containerapp.azure.m.upbound.io_customdomains.yaml
@@ -61,12 +61,13 @@ spec:
                 properties:
                   certificateBindingType:
                     description: |-
-                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
                       The Binding type. Possible values include `Disabled` and `SniEnabled`.
                     type: string
                   containerAppEnvironmentCertificateId:
                     description: The ID of the Container App Environment Certificate
-                      to use. Changing this forces a new resource to be created.
+                      to use. Removing this value (switching to an Azure Managed certificate)
+                      forces a new resource to be created.
                     type: string
                   containerAppEnvironmentCertificateIdRef:
                     description: Reference to a EnvironmentCertificate in containerapp
@@ -253,12 +254,13 @@ spec:
                 properties:
                   certificateBindingType:
                     description: |-
-                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
                       The Binding type. Possible values include `Disabled` and `SniEnabled`.
                     type: string
                   containerAppEnvironmentCertificateId:
                     description: The ID of the Container App Environment Certificate
-                      to use. Changing this forces a new resource to be created.
+                      to use. Removing this value (switching to an Azure Managed certificate)
+                      forces a new resource to be created.
                     type: string
                   containerAppEnvironmentCertificateIdRef:
                     description: Reference to a EnvironmentCertificate in containerapp
@@ -408,12 +410,13 @@ spec:
                 properties:
                   certificateBindingType:
                     description: |-
-                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
                       The Binding type. Possible values include `Disabled` and `SniEnabled`.
                     type: string
                   containerAppEnvironmentCertificateId:
                     description: The ID of the Container App Environment Certificate
-                      to use. Changing this forces a new resource to be created.
+                      to use. Removing this value (switching to an Azure Managed certificate)
+                      forces a new resource to be created.
                     type: string
                   containerAppEnvironmentManagedCertificateId:
                     description: The ID of the Container App Environment Managed Certificate

--- a/package/crds/containerapp.azure.upbound.io_customdomains.yaml
+++ b/package/crds/containerapp.azure.upbound.io_customdomains.yaml
@@ -75,12 +75,13 @@ spec:
                 properties:
                   certificateBindingType:
                     description: |-
-                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
                       The Binding type. Possible values include `Disabled` and `SniEnabled`.
                     type: string
                   containerAppEnvironmentCertificateId:
                     description: The ID of the Container App Environment Certificate
-                      to use. Changing this forces a new resource to be created.
+                      to use. Removing this value (switching to an Azure Managed certificate)
+                      forces a new resource to be created.
                     type: string
                   containerAppEnvironmentCertificateIdRef:
                     description: Reference to a EnvironmentCertificate in containerapp
@@ -255,12 +256,13 @@ spec:
                 properties:
                   certificateBindingType:
                     description: |-
-                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
                       The Binding type. Possible values include `Disabled` and `SniEnabled`.
                     type: string
                   containerAppEnvironmentCertificateId:
                     description: The ID of the Container App Environment Certificate
-                      to use. Changing this forces a new resource to be created.
+                      to use. Removing this value (switching to an Azure Managed certificate)
+                      forces a new resource to be created.
                     type: string
                   containerAppEnvironmentCertificateIdRef:
                     description: Reference to a EnvironmentCertificate in containerapp
@@ -432,12 +434,13 @@ spec:
                 properties:
                   certificateBindingType:
                     description: |-
-                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id. Changing this forces a new resource to be created.
+                      The Certificate Binding type. Possible values are Auto, Disabled and SniEnabled. Required with container_app_environment_certificate_id.
                       The Binding type. Possible values include `Disabled` and `SniEnabled`.
                     type: string
                   containerAppEnvironmentCertificateId:
                     description: The ID of the Container App Environment Certificate
-                      to use. Changing this forces a new resource to be created.
+                      to use. Removing this value (switching to an Azure Managed certificate)
+                      forces a new resource to be created.
                     type: string
                   containerAppEnvironmentManagedCertificateId:
                     description: The ID of the Container App Environment Managed Certificate


### PR DESCRIPTION
### Description of your changes
Update docs for CustomDomain.containerapp to match the removed ForceNew

I have:

- [x] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

~~### How has this code been tested~~

[contribution process]: https://git.io/fj2m9
